### PR TITLE
Added temporary VC hacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ USE_DEBUG := 0
 
 # Build for the N64 (turn this off for ports)
 TARGET_N64 ?= 1
+VC_HACKS ?= 0
 
 # CONSOLE - selects the console to target
 #   bb - Targets the iQue Player (codenamed BB)
@@ -34,6 +35,10 @@ else ifeq ($(CONSOLE),bb)
   INCLUDE_DIRS   += include/ique
   LIBS_DIR       := lib/ique
   DEFINES        += BBPLAYER=1
+endif
+
+ifeq ($(VC_HACKS), 1)
+  DEFINES += VC_HACKS=1
 endif
 
 # COMPILER - selects the C compiler to use
@@ -417,7 +422,7 @@ DEF_INC_CFLAGS := $(foreach i,$(INCLUDE_DIRS),-I$(i)) $(C_DEFINES)
 # C compiler options
 CFLAGS = -G 0 $(OPT_FLAGS) $(TARGET_CFLAGS) $(MIPSISET) $(DEF_INC_CFLAGS)
 ifeq ($(COMPILER),gcc)
-  CFLAGS += -mno-shared -march=vr4300 -mfix4300 -mabi=32 -mhard-float -mdivide-breaks -fno-stack-protector -fno-common -fno-zero-initialized-in-bss -fno-PIC -mno-abicalls -fno-strict-aliasing -fno-inline-functions -ffreestanding -fwrapv -Wall -Wextra -Wno-missing-braces
+  CFLAGS += -mno-shared -march=vr4300 -mfix4300 -mabi=32 -mhard-float -mdivide-breaks -fno-stack-protector -fno-common -fno-zero-initialized-in-bss -fno-PIC -mno-abicalls -fno-strict-aliasing -fno-inline-functions -ffreestanding -fwrapv -Wall -Wextra -Wno-missing-braces -fno-jump-tables
 else
   CFLAGS += -non_shared -Wab,-r4300_mul -Xcpluscomm -Xfullwarn -signed -32
 endif

--- a/src/audio/heap.c
+++ b/src/audio/heap.c
@@ -1087,6 +1087,11 @@ s32 audio_shut_down_and_reset_step(void) {
  * Waits until a specified number of audio frames have been created
  */
 void wait_for_audio_frames(s32 frames) {
+#ifdef VC_HACKS
+    // VC emulator stubs this function because busy loops are not supported
+    // Technically we can put infinite loop that _looks_ like -O0 for emu but this is cleaner
+    return;
+#endif
     gAudioFrameCount = 0;
     // Sound thread will update gAudioFrameCount
     while (gAudioFrameCount < frames) {

--- a/src/game/game_init.c
+++ b/src/game/game_init.c
@@ -384,9 +384,14 @@ void render_init(void) {
     exec_display_list(&gGfxPool->spTask);
 
     // Skip incrementing the initial framebuffer index on emulators so that they display immediately as the Gfx task finishes
+    // VC probably emulates osViSwapBuffer accurately so instant patch breaks VC compatibility
+#ifndef VC_HACKS
     if ((*(volatile u32 *)0xA4100010) != 0) { // Read RDP Clock Register, has a value of zero on emulators
+#endif
         sRenderingFrameBuffer++;
+#ifndef VC_HACKS
     }
+#endif
     gGlobalTimer++;
 }
 
@@ -422,14 +427,18 @@ void display_and_vsync(void) {
     profiler_log_thread5_time(THREAD5_END);
     osRecvMesg(&gGameVblankQueue, &gMainReceivedMesg, OS_MESG_BLOCK);
     // Skip swapping buffers on emulator so that they display immediately as the Gfx task finishes
+#ifndef VC_HACKS
     if ((*(volatile u32 *)0xA4100010) != 0) { // Read RDP Clock Register, has a value of zero on emulators
+#endif
         if (++sRenderedFramebuffer == 3) {
             sRenderedFramebuffer = 0;
         }
         if (++sRenderingFrameBuffer == 3) {
             sRenderingFrameBuffer = 0;
         }
+#ifndef VC_HACKS
     }
+#endif
     gGlobalTimer++;
 }
 


### PR DESCRIPTION
Added define 'VC_HACKS' to stub some code that is needed to be booted on Virtual Console. All those patches can be done in binary except for the new option added '-fno-jump-tables'. Unfortunately gcc code generation is creating code that VC recompiler is unable to understand (jump from main function body after JR RA and then back) so I have to add these flag for hacks that might be VC compatible.

In the future 'VC_HACKS' probably should be removed in favor of compiling code that will be compatible with any console but right now it is TBD.