### PR TITLE
Crash Screen Reports Name of Crashed Function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -766,7 +766,7 @@ $(BUILD_DIR)/rsp/%.bin $(BUILD_DIR)/rsp/%_data.bin: rsp/%.s
 # Run linker script through the C preprocessor
 $(BUILD_DIR)/$(LD_SCRIPT): $(LD_SCRIPT) $(BUILD_DIR)/goddard.txt
 	$(call print,Preprocessing linker script:,$<,$@)
-	$(V)$(CPP) $(CPPFLAGS) -DBUILD_DIR=$(BUILD_DIR) -MMD -MP -MT $@ -MF $@.d -o $@ $<
+	$(V)$(CPP) $(CPPFLAGS) -DBUILD_DIR=$(BUILD_DIR) -D DEBUG_MAP_STACKTRACE -MMD -MP -MT $@ -MF $@.d -o $@ $<
 
 # Link libgoddard
 $(BUILD_DIR)/libgoddard.a: $(GODDARD_O_FILES)

--- a/Makefile
+++ b/Makefile
@@ -575,7 +575,7 @@ $(BUILD_DIR)/src/usb/usb.o: CFLAGS += -Wno-unused-variable -Wno-sign-compare -Wn
 $(BUILD_DIR)/src/usb/debug.o: OPT_FLAGS := -O0
 $(BUILD_DIR)/src/usb/debug.o: CFLAGS += -Wno-unused-parameter -Wno-maybe-uninitialized
 
-ALL_DIRS := $(BUILD_DIR) $(addprefix $(BUILD_DIR)/,$(SRC_DIRS) $(GODDARD_SRC_DIRS) $(LIBZ_SRC_DIRS) $(ULTRA_BIN_DIRS) $(BIN_DIRS) $(TEXTURE_DIRS) $(TEXT_DIRS) $(SOUND_SAMPLE_DIRS) $(addprefix levels/,$(LEVEL_DIRS)) rsp include) $(YAY0_DIR) $(addprefix $(YAY0_DIR)/,$(VERSION)) $(SOUND_BIN_DIR) $(SOUND_BIN_DIR)/sequences/$(VERSION)
+ALL_DIRS := $(BUILD_DIR) $(addprefix $(BUILD_DIR)/,$(SRC_DIRS) asm/debug $(GODDARD_SRC_DIRS) $(LIBZ_SRC_DIRS) $(ULTRA_BIN_DIRS) $(BIN_DIRS) $(TEXTURE_DIRS) $(TEXT_DIRS) $(SOUND_SAMPLE_DIRS) $(addprefix levels/,$(LEVEL_DIRS)) rsp include) $(YAY0_DIR) $(addprefix $(YAY0_DIR)/,$(VERSION)) $(SOUND_BIN_DIR) $(SOUND_BIN_DIR)/sequences/$(VERSION)
 
 # Make sure build directory exists before compiling anything
 DUMMY != mkdir -p $(ALL_DIRS)
@@ -791,10 +791,15 @@ $(BUILD_DIR)/goddard.txt: $(BUILD_DIR)/sm64_prelim.elf
 	$(call print,Getting Goddard size...)
 	$(V)python3 tools/getGoddardSize.py $(BUILD_DIR)/sm64_prelim.map $(VERSION)
 
+$(BUILD_DIR)/asm/debug/map.o: asm/debug/map.s $(BUILD_DIR)/sm64_prelim.elf
+	$(call print,Assembling:,$<,$@)
+	$(V)python3 tools/mapPacker.py $(BUILD_DIR)/sm64_prelim.map $(BUILD_DIR)/bin/addr.bin $(BUILD_DIR)/bin/name.bin
+	$(V)$(CROSS)gcc -c $(ASMFLAGS) $(foreach i,$(INCLUDE_DIRS),-Wa,-I$(i)) -x assembler-with-cpp -MMD -MF $(BUILD_DIR)/$*.d  -o $@ $<
+
 # Link SM64 ELF file
-$(ELF): $(BUILD_DIR)/sm64_prelim.elf $(O_FILES) $(YAY0_OBJ_FILES) $(SEG_FILES) $(BUILD_DIR)/$(LD_SCRIPT) undefined_syms.txt $(BUILD_DIR)/libz.a $(BUILD_DIR)/libgoddard.a
+$(ELF): $(BUILD_DIR)/sm64_prelim.elf $(BUILD_DIR)/asm/debug/map.o $(O_FILES) $(YAY0_OBJ_FILES) $(SEG_FILES) $(BUILD_DIR)/$(LD_SCRIPT) undefined_syms.txt $(BUILD_DIR)/libz.a $(BUILD_DIR)/libgoddard.a
 	@$(PRINT) "$(GREEN)Linking ELF file:  $(BLUE)$@ $(NO_COL)\n"
-	$(V)$(LD) --gc-sections -L $(BUILD_DIR) -T undefined_syms.txt -T $(BUILD_DIR)/$(LD_SCRIPT) -T goddard.txt -Map $(BUILD_DIR)/sm64.$(VERSION).map --no-check-sections $(addprefix -R ,$(SEG_FILES)) -o $@ $(O_FILES) -L$(LIBS_DIR) -l$(ULTRALIB) -Llib $(LINK_LIBRARIES) -u sprintf -u osMapTLB -Llib/gcclib/$(LIBGCCDIR) -lgcc -lnustd -lhvqm2
+	$(V)$(LD) --gc-sections -L $(BUILD_DIR) -T undefined_syms.txt -T $(BUILD_DIR)/$(LD_SCRIPT) -T goddard.txt -Map $(BUILD_DIR)/sm64.$(VERSION).map --no-check-sections $(addprefix -R ,$(SEG_FILES)) -o $@ $(O_FILES) -L$(LIBS_DIR) -l$(ULTRALIB) -Llib $(LINK_LIBRARIES) -u sprintf -u osMapTLB -Llib/gcclib/$(LIBGCCDIR) -lgcc
 
 # Build ROM
 $(ROM): $(ELF)

--- a/asm/debug/map.s
+++ b/asm/debug/map.s
@@ -1,0 +1,17 @@
+.include "macros.inc"
+.section .data
+.balign 16
+glabel gMapEntries
+.incbin "bin/addr.bin"
+glabel gMapEntryEnd
+
+.balign 16
+glabel gMapStrings
+.incbin "bin/name.bin"
+glabel gMapStringsEnd
+
+.balign 16
+glabel gMapEntrySize
+.word (gMapEntryEnd - gMapEntries) / 4
+glabel gMapStringSize
+.word (gMapStringsEnd - gMapStrings)

--- a/sm64.ld
+++ b/sm64.ld
@@ -150,6 +150,7 @@ SECTIONS
 
       BUILD_DIR/src/boot*.o(.text);
       BUILD_DIR/src/hvqm*.o(.text);
+      BUILD_DIR/src/usb*.o(.text);
       BUILD_DIR/src/audio*.o(.text);
 #ifdef S2DEX_TEXT_ENGINE
       lib/libs2d_engine.a:*(.text);
@@ -168,6 +169,7 @@ SECTIONS
 
       /* data */
       BUILD_DIR/src/boot*.o(.*data*);
+      BUILD_DIR/src/usb*.o(.*data*);
       BUILD_DIR/src/audio*.o(.*data*);
 #ifdef S2DEX_TEXT_ENGINE
       lib/libs2d_engine.a:*(.*data*);
@@ -185,6 +187,7 @@ SECTIONS
 
       /* rodata */
       BUILD_DIR/src/boot*.o(.rodata*);
+      BUILD_DIR/src/usb*.o(.rodata*);
       BUILD_DIR/src/audio*.o(.rodata*);
 #ifdef S2DEX_TEXT_ENGINE
       lib/libs2d_engine.a:*(.rodata*);
@@ -199,15 +202,32 @@ SECTIONS
 
       BUILD_DIR/lib/rsp.o(.rodata*);
       lib/PR/hvqm/hvqm2sp1.o(.rodata*);
+#ifndef PRELIMINARY
+      BUILD_DIR/src/game/crash_screen.o(.text*);
+      BUILD_DIR/src/game/crash_screen.o(.data*);
+      BUILD_DIR/src/game/crash_screen.o(.rodata*);
+      BUILD_DIR/src/game/map_parser.o(.text*);
+      BUILD_DIR/src/game/map_parser.o(.data*);
+      BUILD_DIR/src/game/map_parser.o(.rodata*);
+#else
+      parse_map = 0x80345678;
+#endif
    }
    END_SEG(main)
-   #ifndef PRELIMINARY
-      ASSERT((_mainSegmentRomEnd <= 0x101000), "Error: Please shrink your main segment to under 1MB.")
-   #endif
    BEGIN_NOLOAD(main)
    {
+// pad out the space this would've taken
+#ifdef PRELIMINARY
+      BUILD_DIR/src/game/crash_screen.o(.text*);
+      BUILD_DIR/src/game/crash_screen.o(.data*);
+      BUILD_DIR/src/game/crash_screen.o(.rodata*);
+      BUILD_DIR/src/game/map_parser.o(.text*);
+      BUILD_DIR/src/game/map_parser.o(.data*);
+      BUILD_DIR/src/game/map_parser.o(.rodata*);
+#endif
       BUILD_DIR/src/boot*.o(.*bss*);
       BUILD_DIR/src/hvqm*.o(.*bss*);
+      BUILD_DIR/src/usb*.o(.*bss*);
       BUILD_DIR/src/audio*.o(.*bss*);
 #ifdef S2DEX_TEXT_ENGINE
       lib/libs2d_engine.a:*(.*bss*);
@@ -233,23 +253,19 @@ SECTIONS
    {
       BUILD_DIR/src/game*.o(.text);
       BUILD_DIR/src/engine*.o(.text);
-      BUILD_DIR/src/usb*.o(.text);
       /* data */
       BUILD_DIR/src/game*.o(.*data*);
       BUILD_DIR/src/engine*.o(.data*);
       BUILD_DIR/src/engine*.o(.sdata*);
-      BUILD_DIR/src/usb*.o(.*data*);
       /* rodata */
       BUILD_DIR/src/game*.o(.rodata*);
       BUILD_DIR/src/engine*.o(.rodata*);
-      BUILD_DIR/src/usb*.o(.rodata*);
    }
    END_SEG(engine)
    BEGIN_NOLOAD(engine)
    {
       BUILD_DIR/src/game*.o(.*bss*);
       BUILD_DIR/src/engine*.o(.bss*);
-      BUILD_DIR/src/usb*.o(.*bss*);
       . = ALIGN(0x40);
    }
    END_NOLOAD(engine)
@@ -496,6 +512,13 @@ SECTIONS
       KEEP(BUILD_DIR/data/capcom.o(.data));
    }
 	END_SEG(capcom)
+#endif
+
+#ifndef PRELIMINARY
+   BEGIN_SEG(mapData, 0x80700000) {
+      KEEP(BUILD_DIR/asm/debug/map.o(.data*));
+   }
+   END_SEG(mapData)
 #endif
    /* DWARF debug sections.
       Symbols in the DWARF debugging sections are relative to the beginning

--- a/sm64.ld
+++ b/sm64.ld
@@ -144,6 +144,15 @@ SECTIONS
    . = _hvqbufSegmentBssEnd;
 #endif
 
+/* hardcoded symbols to satisfy preliminary link for map parser */
+#ifndef DEBUG_MAP_STACKTRACE
+      parse_map = 0x80345678;
+      _mapDataSegmentRomStart = 0;
+      gMapEntries = 0;
+      gMapEntrySize = 0;
+      gMapStrings = 0;
+#endif
+
    BEGIN_SEG(main, .) SUBALIGN(16)
    {
       KEEP(BUILD_DIR/asm/entry.o(.text));
@@ -202,29 +211,10 @@ SECTIONS
 
       BUILD_DIR/lib/rsp.o(.rodata*);
       lib/PR/hvqm/hvqm2sp1.o(.rodata*);
-#ifndef PRELIMINARY
-      BUILD_DIR/src/game/crash_screen.o(.text*);
-      BUILD_DIR/src/game/crash_screen.o(.data*);
-      BUILD_DIR/src/game/crash_screen.o(.rodata*);
-      BUILD_DIR/src/game/map_parser.o(.text*);
-      BUILD_DIR/src/game/map_parser.o(.data*);
-      BUILD_DIR/src/game/map_parser.o(.rodata*);
-#else
-      parse_map = 0x80345678;
-#endif
    }
    END_SEG(main)
    BEGIN_NOLOAD(main)
    {
-// pad out the space this would've taken
-#ifdef PRELIMINARY
-      BUILD_DIR/src/game/crash_screen.o(.text*);
-      BUILD_DIR/src/game/crash_screen.o(.data*);
-      BUILD_DIR/src/game/crash_screen.o(.rodata*);
-      BUILD_DIR/src/game/map_parser.o(.text*);
-      BUILD_DIR/src/game/map_parser.o(.data*);
-      BUILD_DIR/src/game/map_parser.o(.rodata*);
-#endif
       BUILD_DIR/src/boot*.o(.*bss*);
       BUILD_DIR/src/hvqm*.o(.*bss*);
       BUILD_DIR/src/usb*.o(.*bss*);
@@ -514,7 +504,7 @@ SECTIONS
 	END_SEG(capcom)
 #endif
 
-#ifndef PRELIMINARY
+#ifdef DEBUG_MAP_STACKTRACE
    BEGIN_SEG(mapData, 0x80700000) {
       KEEP(BUILD_DIR/asm/debug/map.o(.data*));
    }

--- a/src/game/crash_screen.c
+++ b/src/game/crash_screen.c
@@ -154,7 +154,7 @@ void crash_screen_print_float_reg(s32 x, s32 y, s32 regNum, void *addr) {
     if ((exponent >= -0x7e && exponent <= 0x7f) || bits == 0) {
         crash_screen_print(x, y, "F%02d:%.3e", regNum, *(f32 *) addr);
     } else {
-        crash_screen_print(x, y, "F%02d:---------", regNum);
+        crash_screen_print(x, y, "F%02d:%08X", regNum, *(u32 *) addr);
     }
 }
 

--- a/src/game/map_parser.c
+++ b/src/game/map_parser.c
@@ -1,0 +1,58 @@
+#include <ultra64.h>
+#include <PR/os_internal_error.h>
+#include <stdarg.h>
+#include <string.h>
+#include "segments.h"
+
+struct MapEntry {
+	u32 addr;
+	u32 nm_offset;
+	u32 nm_len;
+	u32 pad;
+};
+extern u8 gMapStrings[];
+extern struct MapEntry gMapEntries[];
+extern u32 gMapEntrySize;
+extern u8 _mapDataSegmentRomStart[];
+
+u8 *gMapStringAddr;
+struct MapEntry *gMapEntryAddr;
+
+// code provided by Wiseguy
+static s32 headless_dma(u32 devAddr, void *dramAddr, u32 size)
+{
+    register u32 stat;
+    stat = IO_READ(PI_STATUS_REG);
+	while (stat & (PI_STATUS_IO_BUSY | PI_STATUS_DMA_BUSY)) {
+	    stat = IO_READ(PI_STATUS_REG);
+	}
+    IO_WRITE(PI_DRAM_ADDR_REG, K0_TO_PHYS(dramAddr));
+    IO_WRITE(PI_CART_ADDR_REG, K1_TO_PHYS((u32)osRomBase | devAddr));
+    IO_WRITE(PI_WR_LEN_REG, size - 1);
+    return 0;
+}
+static u32 headless_pi_status(void)
+{
+    return IO_READ(PI_STATUS_REG);
+}
+// end of code provided by Wiseguy
+
+
+void map_data_init(void) {
+	headless_dma(_mapDataSegmentRomStart, 0x80700000, 0x100000);
+	while (headless_pi_status() & (PI_STATUS_DMA_BUSY | PI_STATUS_ERROR));
+}
+
+char *parse_map(u32 pc) {
+	u32 i;
+
+	for (i = 0; i < gMapEntrySize; i++) {
+		if (gMapEntries[i].addr >= pc) break;
+	}
+
+	if (i == gMapEntrySize - 1) {
+		return "Unknown";
+	} else {
+		return (char*) ((u32)gMapStrings + gMapEntries[i - 1].nm_offset);
+	}
+}

--- a/src/game/map_parser.c
+++ b/src/game/map_parser.c
@@ -15,8 +15,6 @@ extern struct MapEntry gMapEntries[];
 extern u32 gMapEntrySize;
 extern u8 _mapDataSegmentRomStart[];
 
-u8 *gMapStringAddr;
-struct MapEntry *gMapEntryAddr;
 
 // code provided by Wiseguy
 static s32 headless_dma(u32 devAddr, void *dramAddr, u32 size)

--- a/tools/mapPacker.py
+++ b/tools/mapPacker.py
@@ -1,0 +1,42 @@
+import sys, struct
+
+class MapEntry():
+	def __init__(self, nm, addr):
+		self.name = nm
+		self.addr = addr
+		self.strlen = (len(nm) + 4) & (~3)
+	def __str__(self):
+		return "%s %s %d" % (self.addr, self.name, self.strlen)
+	def __repr__(self):
+		return "%s %s %d" % (self.addr, self.name, self.strlen)
+
+
+structDef = ">LLLL"
+
+symNames = []
+
+with open(sys.argv[1]) as f:
+	for line in f:
+		if "0x000000008" in line and "=" not in line and "." not in line and "*" not in line and "load address" not in line:
+			tokens = line.split()
+			symNames.append(MapEntry(tokens[1], int(tokens[0], 16)))
+
+
+
+f1 = open(sys.argv[2], "wb+")
+f2 = open(sys.argv[3], "wb+")
+
+symNames.sort(key=lambda x: x.addr)
+
+off = 0
+for x in symNames:
+	f1.write(struct.pack(structDef, x.addr, off, len(x.name), 0))
+	f2.write(struct.pack(">%ds" % x.strlen, bytes(x.name, encoding="ascii")))
+	off += x.strlen
+
+
+f1.close()
+f2.close()
+
+# print('\n'.join([str(hex(x.addr)) + " " + x.name for x in symNames]))
+


### PR DESCRIPTION
- print denorms
- import my makefile rules; put map data at the end of the rom
- add map parser init
- add map bin tracker
- map parsing code added
- import map packer script; remove debug print
- allow map debug to be turned off
- remove unnecessary bss
- allow a vector for debug stacktrace to be turned off in the makefile
