### PR TITLE
fixed geo_process_billboard floating point exception

### DIFF
--- a/src/game/rendering_graph_node.c
+++ b/src/game/rendering_graph_node.c
@@ -649,7 +649,7 @@ void geo_process_scale(struct GraphNodeScale *node) {
  */
 void geo_process_billboard(struct GraphNodeBillboard *node) {
     Vec3f translation;
-    Vec3f scale;
+    Vec3f scale = { 1.0f, 1.0f, 1.0f };
 
     vec3s_to_vec3f(translation, node->translation);
 


### PR DESCRIPTION
scale was uninitialized, cause broken billboards on emu, and floating point exception on console.

p.s. should scale be applied to _every_ billboarded command? in vanilla scale is only applied if its an object. might be good to consider for v2.1

Fixes #175 