### PR TITLE
Re-implement Y buffer for find_ceil

### DIFF
--- a/src/engine/surface_collision.c
+++ b/src/engine/surface_collision.c
@@ -329,7 +329,7 @@ f32 find_ceil(f32 posX, f32 posY, f32 posZ, struct Surface **pceil) {
     OSTime first = osGetTime();
 #endif
     s32 x = posX;
-    s32 y = posY;
+    s32 y = posY + FIND_FLOOR_CEIL_BUFFER;
     s32 z = posZ;
     *pceil = NULL;
 
@@ -401,7 +401,7 @@ static struct Surface *find_floor_from_list(struct SurfaceNode *surfaceNode, s32
     register struct Surface *surf, *floor = NULL;
     register SurfaceType type = SURFACE_DEFAULT;
     register f32 height;
-    register s32 bufferY = (y + FIND_FLOOR_BUFFER);
+    register s32 bufferY = (y + FIND_FLOOR_CEIL_BUFFER);
 
     // Iterate through the list of floors until there are no more floors.
     while (surfaceNode != NULL) {
@@ -468,7 +468,7 @@ struct Surface *find_water_floor_from_list(struct SurfaceNode *surfaceNode, s32 
     f32 curHeight = FLOOR_LOWER_LIMIT;
     f32 bottomHeight = FLOOR_LOWER_LIMIT;
     f32 curBottomHeight = FLOOR_LOWER_LIMIT;
-    f32 buffer = FIND_FLOOR_BUFFER;
+    f32 buffer = FIND_FLOOR_CEIL_BUFFER;
 
     // Iterate through the list of water floors until there are no more water floors.
     // SURFACE_NEW_WATER_BOTTOM

--- a/src/engine/surface_collision.h
+++ b/src/engine/surface_collision.h
@@ -7,7 +7,9 @@
 
 #include "engine/extended_bounds.h"
 
-#define FIND_FLOOR_BUFFER               78
+// The y coord is moved upward by this amount when finding floors and ceilings.
+// Vanilla value is 78.
+#define FIND_FLOOR_CEIL_BUFFER          78
 
 #define CELL_HEIGHT_LIMIT            20000
 #define FLOOR_LOWER_LIMIT           -11000


### PR DESCRIPTION
Fixes #200 

In addition to this, the find_floor functions and their helper functions probably should also be changed to match find_ceil/find_ceil_from_list:

find_floor_from_list:
- unused_find_dynamic_floor
- find_floor
find_water_floor_from_list:
- find_water_floor
