### PR TITLE
Allow stop_and_set_height_to_floor to work at any height if Mario is teleporting

### DIFF
--- a/src/game/mario_step.c
+++ b/src/game/mario_step.c
@@ -243,7 +243,7 @@ void stop_and_set_height_to_floor(struct MarioState *m) {
     m->vel[1] = 0.0f;
 
     // Hackersm64: this condition fixes potential downwarps
-    if (m->pos[1] <= m->floorHeight + 160.0f) {
+    if ((m->flags & MARIO_TELEPORTING) || m->pos[1] <= m->floorHeight + 160.0f) {
         m->pos[1] = m->floorHeight;
     }
 

--- a/src/game/mario_step.c
+++ b/src/game/mario_step.c
@@ -242,10 +242,8 @@ void stop_and_set_height_to_floor(struct MarioState *m) {
     mario_set_forward_vel(m, 0.0f);
     m->vel[1] = 0.0f;
 
-    // Hackersm64: this condition fixes potential downwarps
-    if ((m->flags & MARIO_TELEPORTING) || m->pos[1] <= m->floorHeight + 160.0f) {
-        m->pos[1] = m->floorHeight;
-    }
+    //! This is responsible for some downwarps.
+    m->pos[1] = m->floorHeight;
 
     vec3f_copy(marioObj->header.gfx.pos, m->pos);
     vec3s_set(marioObj->header.gfx.angle, 0, m->faceAngle[1], 0);


### PR DESCRIPTION
Fixes #208 