### PR TITLE
Fix how shadows handle water/transparency/height

### DIFF
--- a/src/engine/surface_collision.c
+++ b/src/engine/surface_collision.c
@@ -650,7 +650,7 @@ f32 find_water_floor(s32 xPos, s32 yPos, s32 zPos, struct Surface **pfloor) {
 /**
  * Finds the height of water at a given location.
  */
-s32 find_water_level_and_floor(s32 x, s32 z, struct Surface **pfloor) {
+s32 find_water_level_and_floor(s32 x, s32 y, s32 z, struct Surface **pfloor) {
     s32 val;
     s32 loX, hiX, loZ, hiZ;
     TerrainData *p = gEnvironmentRegions;
@@ -658,7 +658,7 @@ s32 find_water_level_and_floor(s32 x, s32 z, struct Surface **pfloor) {
 #if PUPPYPRINT_DEBUG
     OSTime first = osGetTime();
 #endif
-    s32 waterLevel = find_water_floor(x, ((gCollisionFlags & COLLISION_FLAG_CAMERA) ? gLakituState.pos[1] : gMarioState->pos[1]), z, &floor);
+    s32 waterLevel = find_water_floor(x, y, z, &floor);
 
     if (p != NULL && waterLevel == FLOOR_LOWER_LIMIT) {
         s32 numRegions = *p++;

--- a/src/engine/surface_collision.h
+++ b/src/engine/surface_collision.h
@@ -47,7 +47,7 @@ f32 find_ceil(f32 posX, f32 posY, f32 posZ, struct Surface **pceil);
 f32 find_floor_height(f32 x, f32 y, f32 z);
 f32 find_floor(f32 xPos, f32 yPos, f32 zPos, struct Surface **pfloor);
 f32 find_room_floor(f32 x, f32 y, f32 z, struct Surface **pfloor);
-s32 find_water_level_and_floor(s32 x, s32 z, struct Surface **pfloor);
+s32 find_water_level_and_floor(s32 x, s32 y, s32 z, struct Surface **pfloor);
 s32 find_water_level(s32 x, s32 z);
 s32 find_poison_gas_level(s32 x, s32 z);
 #ifdef VANILLA_DEBUG

--- a/src/game/rendering_graph_node.c
+++ b/src/game/rendering_graph_node.c
@@ -923,9 +923,7 @@ void geo_process_shadow(struct GraphNodeShadow *node) {
             inc_mat_stack();
             geo_append_display_list(
                 (void *) VIRTUAL_TO_PHYSICAL(shadowList),
-                (gCurrShadow.flags & SHADOW_FLAGS_TRANSPARENT)
-                    ? LAYER_TRANSPARENT
-                    : LAYER_TRANSPARENT_DECAL
+                gCurrShadow.isDecal ? LAYER_TRANSPARENT_DECAL : LAYER_TRANSPARENT
             );
 
             gMatStackIndex--;

--- a/src/game/shadow.c
+++ b/src/game/shadow.c
@@ -264,9 +264,9 @@ Gfx *create_shadow_below_xyz(Vec3f pos, s16 shadowScale, u8 shadowSolidity, s8 s
             // Set the shadow height to the lava height in specific areas.
             correct_lava_shadow_height(&floorHeight);
 #endif
-        } else if (gCurrLevelNum == LEVEL_RR
-                   && floor->object != NULL
-                   && floor->object->behavior == segmented_to_virtual(bhvPlatformOnTrack)) {
+        } else if (floor->object != NULL
+                   && floor->object->behavior == segmented_to_virtual(bhvPlatformOnTrack)
+                   && floor->object->oPlatformOnTrackType == PLATFORM_ON_TRACK_TYPE_CARPET) {
             // Raise the shadow 5 units so the shadow doesn't clip into the flying carpet.
             floorHeight += 5;
             // The flying carpet is transparent.

--- a/src/game/shadow.h
+++ b/src/game/shadow.h
@@ -39,34 +39,21 @@ enum ShadowType {
     SHADOW_RECTANGLE_WHOMP            = (1 + SHADOW_RECTANGLE_HARDCODED_OFFSET),
 };
 
-enum ShadowFlags {
-    SHADOW_FLAGS_NONE         = (0 << 0),
-    // Flag for if the current shadow is above water or lava.
-    SHADOW_FLAG_WATER_BOX     = (1 << 0),
-    SHADOW_FLAG_WATER_SURFACE = (1 << 1),
-    // Flag for if Mario is on ice.
-    SHADOW_FLAG_ICE           = (1 << 2),
-    // Flag for if Mario is on a flying carpet.
-    SHADOW_FLAG_CARPET        = (1 << 3),
-};
-#define SHADOW_FLAGS_TRANSPARENT (SHADOW_FLAG_WATER_BOX | SHADOW_FLAG_WATER_SURFACE | SHADOW_FLAG_ICE | SHADOW_FLAG_CARPET)
-
 /**
  * Encapsulation of information about a shadow.
  */
 struct Shadow {
-    /* The y-position of the floor (or water or lava) underneath the object. */
-    f32 floorHeight;
-    /* The floor underneath the object. */
-    struct Surface *floor;
     /* Normal vector of the floor. */
     Vec3f floorNormal;
     /* Size of the shadow. */
     Vec3f scale;
     /* Initial solidity of the shadow, from 0 to 255 (just an alpha value). */
     Alpha solidity;
-    /* Various flags. */
-    s8 flags;
+    /*
+     * Whether the shadow is a decal or not.
+     * It should not be a decal when it's on a transparent surface (water, lava, ice, flying carpet, etc.).
+     */
+    u8 isDecal : 1;
 };
 
 enum ShadowSolidity {

--- a/src/game/shadow.h
+++ b/src/game/shadow.h
@@ -53,7 +53,7 @@ struct Shadow {
      * Whether the shadow is a decal or not.
      * It should not be a decal when it's on a transparent surface (water, lava, ice, flying carpet, etc.).
      */
-    u8 isDecal : 1;
+    s8 isDecal;
 };
 
 enum ShadowSolidity {


### PR DESCRIPTION
This basically just reorders certain shadow calculations.

List of (related) bugs fixed by this:

- Shadows assuming the custom water surfaces' normals are {0.0,1.0,0.0}
- Shadows not being put on the non-decal transparency layer properly
- Distance to floor not being read properly when a water surface/envbox is present
- correct_lava_shadow_height() not being called for object shadows
- Mario's shadow disappearing when 1024 units above the ground (this was intentional functionality for objects, but made platforming from higher up onto a much lower platform harder, so it's reverted for Mario here. Also, this is the only change here that I think can be split into a separate PR if needed).
- find_water_level_and_floor() was only using the camera or Mario's height for everything, causing object shadows on water to appear/disappear depending on Mario's height (this function is only used for shadows, so nothing else should be affected by this)
- #179 
- Probably some other stuff as a side effect