### PR TITLE
Make UNLOCK_ALL apply to more things

### DIFF
--- a/data/behavior_data.c
+++ b/data/behavior_data.c
@@ -2243,12 +2243,16 @@ const BehaviorScript bhvDddWarp[] = {
 
 const BehaviorScript bhvMoatGrills[] = {
     BEGIN(OBJ_LIST_SURFACE),
+#ifdef UNLOCK_ALL
+    DEACTIVATE(),
+#else
     OR_INT(oFlags, OBJ_FLAG_UPDATE_GFX_POS_AND_ANGLE),
     LOAD_COLLISION_DATA(castle_grounds_seg7_collision_moat_grills),
     SET_FLOAT(oCollisionDistance, 30000),
     BEGIN_LOOP(),
         CALL_NATIVE(bhv_moat_grills_loop),
     END_LOOP(),
+#endif
 };
 
 const BehaviorScript bhvClockMinuteHand[] = {
@@ -4428,6 +4432,9 @@ const BehaviorScript bhvSandSoundLoop[] = {
 
 const BehaviorScript bhvHiddenAt120Stars[] = {
     BEGIN(OBJ_LIST_SURFACE),
+#ifdef UNLOCK_ALL
+    DEACTIVATE(),
+#else
     OR_INT(oFlags, OBJ_FLAG_UPDATE_GFX_POS_AND_ANGLE),
     LOAD_COLLISION_DATA(castle_grounds_seg7_collision_cannon_grill),
     SET_FLOAT(oCollisionDistance, 4000),
@@ -4435,6 +4442,7 @@ const BehaviorScript bhvHiddenAt120Stars[] = {
     BEGIN_LOOP(),
         CALL_NATIVE(load_object_collision_model),
     END_LOOP(),
+#endif
 };
 
 const BehaviorScript bhvSnowmansBottom[] = {

--- a/src/game/behaviors/exclamation_box.inc.c
+++ b/src/game/behaviors/exclamation_box.inc.c
@@ -46,10 +46,14 @@ void bhv_rotating_exclamation_mark_loop(void) {
 }
 
 void exclamation_box_act_init(void) {
+#ifdef UNLOCK_ALL
+    u8 tangible = TRUE;
+#else
+    u8 tangible = save_file_get_flags() & sCapSaveFlags[o->oBehParams2ndByte];
+#endif
     if (o->oBehParams2ndByte < EXCLAMATION_BOX_BP_KOOPA_SHELL) {
         o->oAnimState = o->oBehParams2ndByte;
-        if ((save_file_get_flags() & sCapSaveFlags[o->oBehParams2ndByte])
-         || (GET_BPARAM1(o->oBehParams) != EXCLAMATION_BOX_BP1_NEEDS_SWITCH)) {
+        if ((tangible) || (GET_BPARAM1(o->oBehParams) != EXCLAMATION_BOX_BP1_NEEDS_SWITCH)) {
             o->oAction = EXCLAMATION_BOX_ACT_ACTIVE;
         } else {
             o->oAction = EXCLAMATION_BOX_ACT_OUTLINE;

--- a/src/game/behaviors/exclamation_box.inc.c
+++ b/src/game/behaviors/exclamation_box.inc.c
@@ -46,14 +46,15 @@ void bhv_rotating_exclamation_mark_loop(void) {
 }
 
 void exclamation_box_act_init(void) {
-#ifdef UNLOCK_ALL
-    u8 tangible = TRUE;
-#else
-    u8 tangible = save_file_get_flags() & sCapSaveFlags[o->oBehParams2ndByte];
-#endif
     if (o->oBehParams2ndByte < EXCLAMATION_BOX_BP_KOOPA_SHELL) {
         o->oAnimState = o->oBehParams2ndByte;
-        if ((tangible) || (GET_BPARAM1(o->oBehParams) != EXCLAMATION_BOX_BP1_NEEDS_SWITCH)) {
+#ifdef UNLOCK_ALL
+        u8 tangible = TRUE;
+#else
+        u8 tangible = ((save_file_get_flags() & sCapSaveFlags[o->oBehParams2ndByte])
+                    || (GET_BPARAM1(o->oBehParams) != EXCLAMATION_BOX_BP1_NEEDS_SWITCH));
+#endif
+        if (tangible) {
             o->oAction = EXCLAMATION_BOX_ACT_ACTIVE;
         } else {
             o->oAction = EXCLAMATION_BOX_ACT_OUTLINE;

--- a/src/game/behaviors/moat_drainer.inc.c
+++ b/src/game/behaviors/moat_drainer.inc.c
@@ -1,12 +1,12 @@
 // moat_drainer.inc.c
 
 void bhv_invisible_objects_under_bridge_init(void) {
-#ifndef UNLOCK_ALL
+#ifdef UNLOCK_ALL
+    if (TRUE) {
+#else
     if (save_file_get_flags() & SAVE_FLAG_MOAT_DRAINED) {
 #endif
         gEnvironmentRegions[6] = -800;
         gEnvironmentRegions[12] = -800;
-#ifndef UNLOCK_ALL
     }
-#endif
 }

--- a/src/game/behaviors/moat_drainer.inc.c
+++ b/src/game/behaviors/moat_drainer.inc.c
@@ -1,8 +1,12 @@
 // moat_drainer.inc.c
 
 void bhv_invisible_objects_under_bridge_init(void) {
+#ifdef UNLOCK_ALL
     if (save_file_get_flags() & SAVE_FLAG_MOAT_DRAINED) {
+#endif
         gEnvironmentRegions[6] = -800;
         gEnvironmentRegions[12] = -800;
+#ifdef UNLOCK_ALL
     }
+#endif
 }

--- a/src/game/behaviors/moat_drainer.inc.c
+++ b/src/game/behaviors/moat_drainer.inc.c
@@ -1,12 +1,12 @@
 // moat_drainer.inc.c
 
 void bhv_invisible_objects_under_bridge_init(void) {
-#ifdef UNLOCK_ALL
+#ifndef UNLOCK_ALL
     if (save_file_get_flags() & SAVE_FLAG_MOAT_DRAINED) {
 #endif
         gEnvironmentRegions[6] = -800;
         gEnvironmentRegions[12] = -800;
-#ifdef UNLOCK_ALL
+#ifndef UNLOCK_ALL
     }
 #endif
 }

--- a/src/game/behaviors/mushroom_1up.inc.c
+++ b/src/game/behaviors/mushroom_1up.inc.c
@@ -29,6 +29,7 @@ void bhv_1up_common_init(void) {
 
 void bhv_1up_init(void) {
     bhv_1up_common_init();
+#ifndef UNLOCK_ALL
     if (o->oBehParams2ndByte == MUSHROOM_BP_REQUIRES_BOWSER_1) {
         if (!(save_file_get_flags() & (SAVE_FLAG_HAVE_KEY_1 | SAVE_FLAG_UNLOCKED_BASEMENT_DOOR))) {
             o->activeFlags = ACTIVE_FLAG_DEACTIVATED;
@@ -38,6 +39,7 @@ void bhv_1up_init(void) {
             o->activeFlags = ACTIVE_FLAG_DEACTIVATED;
         }
     }
+#endif
 }
 
 void one_up_loop_in_air(void) {

--- a/src/game/behaviors/water_pillar.inc.c
+++ b/src/game/behaviors/water_pillar.inc.c
@@ -68,9 +68,13 @@ void water_level_pillar_drained(void) {
 }
 
 void bhv_water_level_pillar_init(void) {
+#ifdef UNLOCK_ALL
+    o->oWaterLevelPillarDrained = TRUE;
+#else
     if (save_file_get_flags() & SAVE_FLAG_MOAT_DRAINED) {
         o->oWaterLevelPillarDrained = TRUE;
     }
+#endif
 }
 
 void bhv_water_level_pillar_loop(void) {

--- a/src/game/behaviors/yoshi.inc.c
+++ b/src/game/behaviors/yoshi.inc.c
@@ -11,12 +11,14 @@ void bhv_yoshi_init(void) {
     o->oBuoyancy = 1.3f;
     o->oInteractionSubtype = INT_SUBTYPE_NPC;
 
-#ifdef ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS
+#if defined(ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS) || defined(UNLOCK_ALL)
+    if (sYoshiDead == TRUE) {
+#else
     if ((save_file_get_total_star_count(gCurrSaveFileNum - 1, COURSE_NUM_TO_INDEX(COURSE_MIN), COURSE_NUM_TO_INDEX(COURSE_MAX)) < 120)
         || sYoshiDead == TRUE) {
+#endif
         o->activeFlags = ACTIVE_FLAG_DEACTIVATED;
     }
-#endif
 }
 
 void yoshi_walk_loop(void) {

--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -488,10 +488,16 @@ void check_instant_warp(void) {
     s16 cameraAngle;
     struct Surface *floor;
 
+#ifdef ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS
+ #ifdef UNLOCK_ALL
+    if (gCurrLevelNum == LEVEL_CASTLE) {
+ #else // !UNLOCK_ALL
     if (gCurrLevelNum == LEVEL_CASTLE
         && save_file_get_total_star_count(gCurrSaveFileNum - 1, COURSE_MIN - 1, COURSE_MAX - 1) >= 70) {
+ #endif // !UNLOCK_ALL
         return;
     }
+#endif // ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS
 
     if ((floor = gMarioState->floor) != NULL) {
         s32 index = floor->type - SURFACE_INSTANT_WARP_1B;

--- a/src/game/mario_actions_stationary.c
+++ b/src/game/mario_actions_stationary.c
@@ -1039,8 +1039,12 @@ s32 act_first_person(struct MarioState *m) {
         return set_mario_action(m, ACT_IDLE, 0);
     }
 
-    if (m->floor->type == SURFACE_LOOK_UP_WARP
+#ifdef UNLOCK_ALL
+    if (m->floor != NULL && m->floor->type == SURFACE_LOOK_UP_WARP) {
+#else
+    if (m->floor != NULL && m->floor->type == SURFACE_LOOK_UP_WARP
         && save_file_get_total_star_count(gCurrSaveFileNum - 1, COURSE_MIN - 1, COURSE_MAX - 1) >= 10) {
+#endif
         s16 headRX = m->statusForCamera->headRotation[0];
         s16 totalRY = ((m->statusForCamera->headRotation[1] * 4) / 3) + m->faceAngle[1];
         if (headRX == -0x1800 && (totalRY < -0x6FFF || totalRY >= 0x7000)) {

--- a/src/game/mario_actions_stationary.c
+++ b/src/game/mario_actions_stationary.c
@@ -1040,9 +1040,9 @@ s32 act_first_person(struct MarioState *m) {
     }
 
 #ifdef UNLOCK_ALL
-    if (m->floor != NULL && m->floor->type == SURFACE_LOOK_UP_WARP) {
+    if (m->floor->type == SURFACE_LOOK_UP_WARP) {
 #else
-    if (m->floor != NULL && m->floor->type == SURFACE_LOOK_UP_WARP
+    if (m->floor->type == SURFACE_LOOK_UP_WARP
         && save_file_get_total_star_count(gCurrSaveFileNum - 1, COURSE_MIN - 1, COURSE_MAX - 1) >= 10) {
 #endif
         s16 headRX = m->statusForCamera->headRotation[0];

--- a/src/game/mario_misc.c
+++ b/src/game/mario_misc.c
@@ -183,50 +183,42 @@ void bhv_toad_message_loop(void) {
 
 void bhv_toad_message_init(void) {
     s32 saveFlags = save_file_get_flags();
-#ifndef UNLOCK_ALL
+#ifdef UNLOCK_ALL
+    s32 starCount = 999;
+#else
     s32 starCount = save_file_get_total_star_count(gCurrSaveFileNum - 1, COURSE_MIN - 1, COURSE_MAX - 1);
-    s32 enoughStars = TRUE;
 #endif
     s32 dialogId = GET_BPARAM1(o->oBehParams);
+    s32 enoughStars = TRUE;
 
     switch (dialogId) {
         case TOAD_STAR_1_DIALOG:
-#ifndef UNLOCK_ALL
             enoughStars = (starCount >= TOAD_STAR_1_REQUIREMENT);
-#endif
             if (saveFlags & SAVE_FLAG_COLLECTED_TOAD_STAR_1) {
                 dialogId = TOAD_STAR_1_DIALOG_AFTER;
             }
             break;
         case TOAD_STAR_2_DIALOG:
-#ifndef UNLOCK_ALL
             enoughStars = (starCount >= TOAD_STAR_2_REQUIREMENT);
-#endif
             if (saveFlags & SAVE_FLAG_COLLECTED_TOAD_STAR_2) {
                 dialogId = TOAD_STAR_2_DIALOG_AFTER;
             }
             break;
         case TOAD_STAR_3_DIALOG:
-#ifndef UNLOCK_ALL
             enoughStars = (starCount >= TOAD_STAR_3_REQUIREMENT);
-#endif
             if (saveFlags & SAVE_FLAG_COLLECTED_TOAD_STAR_3) {
                 dialogId = TOAD_STAR_3_DIALOG_AFTER;
             }
             break;
     }
-#ifndef UNLOCK_ALL
     if (enoughStars) {
-#endif
         o->oToadMessageDialogId = dialogId;
         o->oToadMessageRecentlyTalked = FALSE;
         o->oToadMessageState = TOAD_MESSAGE_FADED;
         o->oOpacity = 81;
-#ifndef UNLOCK_ALL
     } else {
         obj_mark_for_deletion(o);
     }
-#endif
 }
 
 static void star_door_unlock_spawn_particles(s16 angleOffset) {

--- a/src/game/mario_misc.c
+++ b/src/game/mario_misc.c
@@ -183,38 +183,50 @@ void bhv_toad_message_loop(void) {
 
 void bhv_toad_message_init(void) {
     s32 saveFlags = save_file_get_flags();
+#ifndef UNLOCK_ALL
     s32 starCount = save_file_get_total_star_count(gCurrSaveFileNum - 1, COURSE_MIN - 1, COURSE_MAX - 1);
-    s32 dialogId = GET_BPARAM1(o->oBehParams);
     s32 enoughStars = TRUE;
+#endif
+    s32 dialogId = GET_BPARAM1(o->oBehParams);
 
     switch (dialogId) {
         case TOAD_STAR_1_DIALOG:
+#ifndef UNLOCK_ALL
             enoughStars = (starCount >= TOAD_STAR_1_REQUIREMENT);
+#endif
             if (saveFlags & SAVE_FLAG_COLLECTED_TOAD_STAR_1) {
                 dialogId = TOAD_STAR_1_DIALOG_AFTER;
             }
             break;
         case TOAD_STAR_2_DIALOG:
+#ifndef UNLOCK_ALL
             enoughStars = (starCount >= TOAD_STAR_2_REQUIREMENT);
+#endif
             if (saveFlags & SAVE_FLAG_COLLECTED_TOAD_STAR_2) {
                 dialogId = TOAD_STAR_2_DIALOG_AFTER;
             }
             break;
         case TOAD_STAR_3_DIALOG:
+#ifndef UNLOCK_ALL
             enoughStars = (starCount >= TOAD_STAR_3_REQUIREMENT);
+#endif
             if (saveFlags & SAVE_FLAG_COLLECTED_TOAD_STAR_3) {
                 dialogId = TOAD_STAR_3_DIALOG_AFTER;
             }
             break;
     }
+#ifndef UNLOCK_ALL
     if (enoughStars) {
+#endif
         o->oToadMessageDialogId = dialogId;
         o->oToadMessageRecentlyTalked = FALSE;
         o->oToadMessageState = TOAD_MESSAGE_FADED;
         o->oOpacity = 81;
+#ifndef UNLOCK_ALL
     } else {
         obj_mark_for_deletion(o);
     }
+#endif
 }
 
 static void star_door_unlock_spawn_particles(s16 angleOffset) {

--- a/src/game/puppycam2.c
+++ b/src/game/puppycam2.c
@@ -1092,12 +1092,17 @@ void puppycam_projection_behaviours(void) {
         // puppycam_wall_angle();
 
 #ifdef ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS
-if (gMarioState->floor != NULL && gMarioState->floor->type == SURFACE_LOOK_UP_WARP && save_file_get_total_star_count(gCurrSaveFileNum - 1, COURSE_MIN - 1, COURSE_MAX - 1) >= 10) {
+ #ifdef UNLOCK_ALL
+    if (gMarioState->floor != NULL && gMarioState->floor->type == SURFACE_LOOK_UP_WARP) {
+ #else // !UNLOCK_ALL
+    if (gMarioState->floor != NULL && gMarioState->floor->type == SURFACE_LOOK_UP_WARP
+        && save_file_get_total_star_count(gCurrSaveFileNum - 1, COURSE_MIN - 1, COURSE_MAX - 1) >= 10) {
+ #endif // !UNLOCK_ALL
         if (gPuppyCam.pitchTarget >= 0x7000) {
             level_trigger_warp(gMarioState, WARP_OP_LOOK_UP);
         }
     }
-#endif
+#endif // ENABLE_VANILLA_LEVEL_SPECIFIC_CHECKS
     } else {
         puppycam_reset_values();
     }


### PR DESCRIPTION
Now it also applies to:

- WMOTR warp (both regular and puppycam)
- Drained moat
- 1-Ups that only appear after Bowser 1 or 2 is beaten
- Yoshi
- Endless stairs
- Castle Toad stars

Fixes #229 