### PR TITLE
Renamed HD_INTRO_TEXTURES define, separated intro floombas

### DIFF
--- a/data/behavior_data.c
+++ b/data/behavior_data.c
@@ -5137,7 +5137,7 @@ const BehaviorScript bhvFloomba[] = {
     GOTO(bhvGoomba + 1),
 };
 
-#ifdef HD_INTRO_TEXTURES
+#ifdef INTRO_FLOOMBAS
 const BehaviorScript bhvFloombaStartup[] = {
     BEGIN(OBJ_LIST_PUSHABLE),
     SET_INT(oIsFloomba, TRUE),

--- a/include/behavior_data.h
+++ b/include/behavior_data.h
@@ -452,7 +452,7 @@ extern const BehaviorScript bhvGoomba[];
 extern const BehaviorScript bhvGoombaTripletSpawner[];
 #ifdef FLOOMBAS
 extern const BehaviorScript bhvFloomba[];
-#ifdef HD_INTRO_TEXTURES
+#ifdef INTRO_FLOOMBAS
 extern const BehaviorScript bhvFloombaStartup[];
 #endif
 extern const BehaviorScript bhvFloombaTripletSpawner[];

--- a/include/config/config_graphics.h
+++ b/include/config/config_graphics.h
@@ -4,8 +4,11 @@
  * GRAPHICS SETTINGS *
  *********************/
 
-// Use HD versions of the intro splash screen textures. This includes "Made with HackerSM64".
-#define HD_INTRO_TEXTURES
+// Show a watermark in the title screen that reads "Made with HackerSM64", instead of the copyright message
+#define INTRO_CREDIT
+
+// Spawn floombas in the title screen
+#define INTRO_FLOOMBAS
 
 // Enable widescreen (16:9) support
 #define WIDE
@@ -90,3 +93,7 @@
 #define F3DEX2_REJ_GBI
 #define F3DLX2_REJ_GBI
 #endif // OBJECTS_REJ
+// Enable floombas if the intro floombas are enabled
+#ifdef INTRO_FLOOMBAS
+#define FLOOMBAS
+#endif

--- a/include/object_constants.h
+++ b/include/object_constants.h
@@ -1553,7 +1553,7 @@ enum animIDsSwoop {
     #define GOOMBA_SIZE_TINY                                0x02
     #define GOOMBA_BP_SIZE_MASK                             0x03
     #define GOOMBA_BP_TRIPLET_FLAG_MASK                     0xFC
-#if defined(FLOOMBAS) && defined(HD_INTRO_TEXTURES)
+#if defined(FLOOMBAS) && defined(INTRO_FLOOMBAS)
     /* BPARAM3 */
     #define GOOMBA_BP3_FLOOMBA_MIRRORED_STARTUP_ANIM        (1 << 7)
 #endif
@@ -1561,7 +1561,7 @@ enum animIDsSwoop {
     #define GOOMBA_ACT_WALK                                 0x0
     #define GOOMBA_ACT_ATTACKED_MARIO                       0x1
     #define GOOMBA_ACT_JUMP                                 0x2
-#if defined(HD_INTRO_TEXTURES) && defined(FLOOMBAS)
+#if defined(FLOOMBAS) && defined(INTRO_FLOOMBAS)
     #define FLOOMBA_ACT_STARTUP                             0x3
 #endif
     /* oAnimState */

--- a/include/object_fields.h
+++ b/include/object_fields.h
@@ -605,7 +605,7 @@
 #ifdef FLOOMBAS
 #define /*0x110*/ oIsFloomba OBJECT_FIELD_S32(0x22)
 
-#ifdef HD_INTRO_TEXTURES
+#ifdef INTRO_FLOOMBAS
 #define /*0x1AC*/ oZoomCounter OBJECT_FIELD_S32(0x49)
 #define /*0x1B0*/ oZoomPosZ    OBJECT_FIELD_F32(0x4A)
 #endif

--- a/levels/intro/geo.c
+++ b/levels/intro/geo.c
@@ -35,7 +35,7 @@ const GeoLayout intro_geo_splash_screen[] = {
             GEO_CAMERA(CAMERA_MODE_NONE, 0, 0, 3200, 0, 0, 0, 0x00000000),
             GEO_OPEN_NODE(),
                GEO_ASM(0, geo_intro_super_mario_64_logo),
-#if defined(HD_INTRO_TEXTURES) && defined(FLOOMBAS)
+#if defined(FLOOMBAS) && defined(INTRO_FLOOMBAS)
                GEO_RENDER_OBJ(),
 #endif
             GEO_CLOSE_NODE(),

--- a/levels/intro/leveldata.c
+++ b/levels/intro/leveldata.c
@@ -3319,7 +3319,7 @@ const Gfx intro_seg7_dl_main_logo[] = {
 
 // 0x0700B420 - 0x0700B460
 static const Vtx intro_seg7_vertex_copyright[] = {
-#ifdef HD_INTRO_TEXTURES
+#ifdef INTRO_CREDIT
     {{{    80,     60,     -1}, 0, {     0,      0}, {0x00, 0xff, 0xf7, 0xff}}}, // 0
     {{{   240,     60,     -1}, 0, {256<<5,      0}, {0x00, 0xff, 0xf7, 0xff}}}, // 1
 
@@ -3338,7 +3338,7 @@ static const Vtx intro_seg7_vertex_copyright[] = {
 
 // 0x0700B460 - 0x0700B4A0
 static const Vtx intro_seg7_vertex_trademark[] = {
-#ifdef HD_INTRO_TEXTURES
+#ifdef INTRO_CREDIT
     {{{   268,    192,     -1}, 0, {     0,      0}, {0x00, 0xff, 0xf7, 0xff}}}, // 0
     {{{   284,    192,     -1}, 0, { 64<<5,      0}, {0x00, 0xff, 0xf7, 0xff}}}, // 1
 
@@ -3355,7 +3355,7 @@ static const Vtx intro_seg7_vertex_trademark[] = {
 #endif
 };
 
-#ifdef HD_INTRO_TEXTURES
+#ifdef INTRO_CREDIT
 // 0x0700B4A0 - 0x0700B4A2
 ALIGNED8 static const Texture intro_seg7_texture_copyright[] = {
 #include "levels/intro/made_with_hackersm64.custom.i4.inc.c"
@@ -3399,7 +3399,7 @@ ALIGNED8 static const Texture intro_seg7_texture_trademark[] = {
 // 0x0700C6A0 - 0x0700C790
 const Gfx intro_seg7_dl_copyright_trademark[] = {
     gsDPPipeSync(),
-#ifdef HD_INTRO_TEXTURES
+#ifdef INTRO_CREDIT
     gsDPSetCombineMode(G_CC_MODULATEFADE, G_CC_MODULATEFADE),
 #else
     gsDPSetCombineMode(G_CC_DECALFADE, G_CC_DECALFADE),
@@ -3407,7 +3407,7 @@ const Gfx intro_seg7_dl_copyright_trademark[] = {
     gsDPSetTextureFilter(G_TF_POINT),
     gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON),
 
-#ifdef HD_INTRO_TEXTURES
+#ifdef INTRO_CREDIT
     gsDPLoadTextureBlock_4b(intro_seg7_texture_copyright, G_IM_FMT_I, 256, 32, (G_TX_NOMIRROR | G_TX_CLAMP), (G_TX_NOMIRROR | G_TX_CLAMP), 0, 8, 5, G_TX_NOLOD, G_TX_NOLOD),
     gsSPVertex(intro_seg7_vertex_copyright, 6, 0),
     gsSP2Triangles( 0,  3,  1, 0x0,  0,  2,  3, 0x0),

--- a/levels/intro/script.c
+++ b/levels/intro/script.c
@@ -33,7 +33,7 @@ const LevelScript level_intro_splash_screen[] = {
     LOAD_GODDARD(),
     LOAD_BEHAVIOR_DATA(),
     LOAD_LEVEL_DATA(intro),
-#if defined(HD_INTRO_TEXTURES) && defined(FLOOMBAS)
+#if defined(FLOOMBAS) && defined(INTRO_FLOOMBAS)
     LOAD_COMMON0(),
 
     // Load "Super Mario 64" logo

--- a/src/game/behaviors/goomba.inc.c
+++ b/src/game/behaviors/goomba.inc.c
@@ -124,7 +124,7 @@ void bhv_goomba_init(void) {
     if (o->oIsFloomba) {
         o->oAnimState += FLOOMBA_ANIM_STATE_EYES_OPEN;
     }
-#ifdef HD_INTRO_TEXTURES
+#ifdef INTRO_FLOOMBAS
     if (o->oAction == FLOOMBA_ACT_STARTUP) {
         o->oZoomPosZ = o->oPosZ;
         o->oGoombaScale = 0.0f;
@@ -266,7 +266,7 @@ static void goomba_act_jump(void) {
     }
 }
 
-#if defined(FLOOMBAS) && defined(HD_INTRO_TEXTURES)
+#if defined(FLOOMBAS) && defined(INTRO_FLOOMBAS)
 static void floomba_act_startup(void) {
     if (GET_BPARAM3(o->oBehParams) & GOOMBA_BP3_FLOOMBA_MIRRORED_STARTUP_ANIM) {
         struct Animation *currAnim = o->header.gfx.animInfo.curAnim;
@@ -335,7 +335,7 @@ void bhv_goomba_update(void) {
         if (o->oGoombaScale == 0.0f || (animSpeed = (o->oForwardVel / o->oGoombaScale * 0.4f)) < 1.0f) {
             animSpeed = 1.0f;
         }
-#if defined(FLOOMBAS) && defined(HD_INTRO_TEXTURES)
+#if defined(FLOOMBAS) && defined(INTRO_FLOOMBAS)
         if (o->oAction == FLOOMBA_ACT_STARTUP) {
             animSpeed = (GET_BPARAM1(o->oBehParams) / 16.0f);
         }
@@ -352,7 +352,7 @@ void bhv_goomba_update(void) {
             case GOOMBA_ACT_JUMP:
                 goomba_act_jump();
                 break;
-#if defined(FLOOMBAS) && defined(HD_INTRO_TEXTURES)
+#if defined(FLOOMBAS) && defined(INTRO_FLOOMBAS)
             case FLOOMBA_ACT_STARTUP:
                 floomba_act_startup();
                 break;


### PR DESCRIPTION
- `HD_INTRO_TEXTURES` was renamed to `INTRO_CREDIT`
- Created a new define that controls whether to spawn the floombas in the title screen ( `INTRO_FLOOMBAS`). Previously, it was force enabled if both the watermark and the floombas were enabled.
- Enabling `INTRO_FLOOMBAS` automatically enables `FLOOMBAS`

There are no new features here, it just makes the defines regarding the intro less confusing and more flexible. 