### PR TITLE
Remove CUSTOM_DEBUG define

### DIFF
--- a/include/config/config_debug.h
+++ b/include/config/config_debug.h
@@ -39,9 +39,6 @@
 // This will not overwrite existing save file data unless you save over it.
 // #define COMPLETE_SAVE_FILE
 
-// Custom debug mode. Press DPAD left to show the debug UI. Press DPAD right to enter the noclip mode.
-// #define CUSTOM_DEBUG
-
 // Removes the limit on FPS
 // #define UNLOCK_FPS
 

--- a/src/game/game_init.c
+++ b/src/game/game_init.c
@@ -45,9 +45,6 @@ OSContPad gControllerPads[4];
 u8 gControllerBits;
 u8 gIsConsole = TRUE; // Needs to be initialized before audio_reset_session is called
 u8 gBorderHeight;
-#ifdef CUSTOM_DEBUG
-u8 gCustomDebugMode;
-#endif
 #ifdef EEP
 s8 gEepromProbe;
 #endif

--- a/src/game/game_init.h
+++ b/src/game/game_init.h
@@ -49,9 +49,6 @@ extern struct GfxPool *gGfxPool;
 extern u8 gControllerBits;
 extern u8 gIsConsole;
 extern u8 gBorderHeight;
-#ifdef CUSTOM_DEBUG
-extern u8 gCustomDebugMode;
-#endif
 extern u8 *gAreaSkyboxStart[AREA_COUNT];
 extern u8 *gAreaSkyboxEnd[AREA_COUNT];
 #ifdef EEP

--- a/src/game/hud.c
+++ b/src/game/hud.c
@@ -399,18 +399,6 @@ void render_hud_mario_lives(void) {
     print_text_fmt_int(GFX_DIMENSIONS_RECT_FROM_LEFT_EDGE(54), HUD_TOP_Y, "%d", gHudDisplay.lives);
 }
 
-#ifdef CUSTOM_DEBUG
-void render_debug_mode(void) {
-    print_text(180, 40, "DEBUG MODE");
-    print_text_fmt_int(5, 20, "Z %d", gMarioState->pos[2]);
-    print_text_fmt_int(5, 40, "Y %d", gMarioState->pos[1]);
-    print_text_fmt_int(5, 60, "X %d", gMarioState->pos[0]);
-    print_text_fmt_int(10, 100, "SPD %d", (s32) gMarioState->forwardVel);
-    print_text_fmt_int(10, 120, "ANG 0*%04x", (u16) gMarioState->faceAngle[1]);
-    print_fps(10,80);
-}
-#endif
-
 /**
  * Renders the amount of coins collected.
  */
@@ -603,11 +591,6 @@ void render_hud(void) {
         if (gSurfacePoolError & NOT_ENOUGH_ROOM_FOR_SURFACES) print_text(10, 40, "SURFACE POOL FULL");
         if (gSurfacePoolError & NOT_ENOUGH_ROOM_FOR_NODES) print_text(10, 60, "SURFACE NODE POOL FULL");
 
-#ifdef CUSTOM_DEBUG
-        if (gCustomDebugMode) {
-            render_debug_mode();
-        }
-#endif
 #ifdef PUPPYPRINT
         print_set_envcolour(255, 255, 255, 255);
 #endif

--- a/src/game/mario.c
+++ b/src/game/mario.c
@@ -1213,23 +1213,6 @@ void update_mario_button_inputs(struct MarioState *m) {
     if (m->controller->buttonPressed & A_BUTTON) m->input |= INPUT_A_PRESSED;
     if (m->controller->buttonDown    & A_BUTTON) m->input |= INPUT_A_DOWN;
 
-#ifdef CUSTOM_DEBUG
-    if (m->controller->buttonPressed & L_JPAD) {
-        gCustomDebugMode ^= 1;
-    }
-    if (gCustomDebugMode) {
-        if (m->controller->buttonPressed & R_JPAD) {
-            if (gMarioState->action == ACT_DEBUG_FREE_MOVE) {
-                set_mario_action(gMarioState, ACT_IDLE, 0);
-            } else {
-                set_mario_action(gMarioState, ACT_DEBUG_FREE_MOVE, 0);
-            }
-        }
-    } else if (gMarioState->action == ACT_DEBUG_FREE_MOVE) {
-        set_mario_action(gMarioState, ACT_IDLE, 0);
-    }
-#endif
-
     // Don't update for these buttons if squished.
     if (m->squishTimer == 0) {
         if (m->controller->buttonDown    & B_BUTTON) m->input |= INPUT_B_DOWN;


### PR DESCRIPTION
It makes no sense to keep this ever since the much better puppyprint debugger was introduced