### PR TITLE
Fix hardcoded cos values in sm64.h

### DIFF
--- a/include/sm64.h
+++ b/include/sm64.h
@@ -32,28 +32,30 @@
 
 // Common cos values for degrees, often used for surface Y normals
 // These are different than coss()
-#define COS1    0.9998477f
-#define COS5    0.9961947f
-#define COS10   0.9848077f
-#define COS15   0.9659258f
-#define COS20   0.9396926f
-#define COS25   0.9063078f  // ledge grabs
-#define COS30   0.8660254f
-#define COS35   0.85264016f
-#define COS36   0.8443279f
-#define COS38   0.7880108f  // mario_floor_is_slippery default
-#define COS40   0.80901699f
-#define COS45   0.76040596f
-#define COS50   0.70710678f // SURFACE_FLAG_X_PROJECTION
-#define COS55   0.64944805f
-#define COS60   0.58778525f
-#define COS65   0.52249856f
-#define COS70   0.4539905f
+#define COS0    1.0f
+#define COS1    0.99984770f // mario_floor_is_slippery, mario_floor_is_slope
+#define COS5    0.99619470f // mario_floor_is_slope
+#define COS10   0.98480775f // act_butt_slide_air, act_hold_butt_slide_air, mario_floor_is_slippery, mario_floor_is_slope
+#define COS15   0.96592583f // mario_floor_is_slope
+#define COS20   0.93969262f // mario_floor_is_slippery, mario_floor_is_slope, mario_floor_is_steep
+#define COS25   0.90630779f // ledge grabs
+#define COS30   0.86602540f // should_get_stuck_in_ground, mario_floor_is_steep
+#define COS35   0.81915204f
+#define COS36   0.80901699f
+#define COS38   0.78801075f // mario_floor_is_slippery default
+#define COS40   0.76604444f
+#define COS45   0.70710678f // SURFACE_FLAG_X_PROJECTION
+#define COS50   0.64278761f
+#define COS55   0.57357644f
+#define COS60   0.5f
+#define COS65   0.42261826f
+#define COS70   0.34202014f
 #define COS73   0.29237169f // common_landing_cancels, check_common_idle_cancels, check_common_hold_idle_cancels
-#define COS75   0.38268343f
+#define COS75   0.25881905f
 #define COS78   0.20791169f
 #define COS80   0.17364818f // braking action
-#define COS85   0.23344536f
+#define COS85   0.087155743f
+#define COS90   0.0f
 
 enum RenderLayers {
     LAYER_FORCE,


### PR DESCRIPTION
Previously, some of them were calculated using gradians.