### PR TITLE
Enable rumble by default and remove warning

### DIFF
--- a/include/config/config_rom.h
+++ b/include/config/config_rom.h
@@ -9,8 +9,7 @@
 #define INTERNAL_ROM_NAME "HackerSM64          "
 
 // Support Rumble Pak
-// Currently not recommended, as it may cause random crashes.
-//#define ENABLE_RUMBLE (1 || VERSION_SH)
+#define ENABLE_RUMBLE (1 || VERSION_SH)
 
 // Clear RAM on boot
 #define CLEARRAM 1


### PR DESCRIPTION
The crash issues were fixed on ultrasm64 some time ago, so rumble should be enabled by default and the warning is now outdated.