### PR TITLE
Combine functions for rendering save file menu buttons

### DIFF
--- a/src/menu/file_select.c
+++ b/src/menu/file_select.c
@@ -463,38 +463,44 @@ static const Vec3s sSaveFileButtonPositions[] = {
 #define MENU_BUTTON_SCALE 0.11111111f
 
 /**
- * Render buttons for the score menu.
+ * Render buttons for the menu.
  * Also check if the save file exists to render a different Mario button.
  */
-void render_score_menu_buttons(struct Object *scoreButton) {
+void render_menu_buttons(s32 selectedButtonID) {
+    struct Object *button = sMainMenuButtons[selectedButtonID];
+    // MENU_BUTTON_SCORE ->  7
+    // MENU_BUTTON_COPY  -> 14
+    // MENU_BUTTON_ERASE -> 21
+    s32 idx = (selectedButtonID - 3) * 7;
+
     // File A
-    sMainMenuButtons[MENU_BUTTON_SCORE_FILE_A] = SPAWN_FILE_SELECT_FILE_BUTTON(scoreButton, SAVE_FILE_A);
-    sMainMenuButtons[MENU_BUTTON_SCORE_FILE_A]->oMenuButtonScale = MENU_BUTTON_SCALE;
+    sMainMenuButtons[idx + 0] = SPAWN_FILE_SELECT_FILE_BUTTON(button, SAVE_FILE_A);
+    sMainMenuButtons[idx + 0]->oMenuButtonScale = MENU_BUTTON_SCALE;
     // File B
-    sMainMenuButtons[MENU_BUTTON_SCORE_FILE_B] = SPAWN_FILE_SELECT_FILE_BUTTON(scoreButton, SAVE_FILE_B);
-    sMainMenuButtons[MENU_BUTTON_SCORE_FILE_B]->oMenuButtonScale = MENU_BUTTON_SCALE;
+    sMainMenuButtons[idx + 1] = SPAWN_FILE_SELECT_FILE_BUTTON(button, SAVE_FILE_B);
+    sMainMenuButtons[idx + 1]->oMenuButtonScale = MENU_BUTTON_SCALE;
     // File C
-    sMainMenuButtons[MENU_BUTTON_SCORE_FILE_C] = SPAWN_FILE_SELECT_FILE_BUTTON(scoreButton, SAVE_FILE_C);
-    sMainMenuButtons[MENU_BUTTON_SCORE_FILE_C]->oMenuButtonScale = MENU_BUTTON_SCALE;
+    sMainMenuButtons[idx + 2] = SPAWN_FILE_SELECT_FILE_BUTTON(button, SAVE_FILE_C);
+    sMainMenuButtons[idx + 2]->oMenuButtonScale = MENU_BUTTON_SCALE;
     // File D
-    sMainMenuButtons[MENU_BUTTON_SCORE_FILE_D] = SPAWN_FILE_SELECT_FILE_BUTTON(scoreButton, SAVE_FILE_D);
-    sMainMenuButtons[MENU_BUTTON_SCORE_FILE_D]->oMenuButtonScale = MENU_BUTTON_SCALE;
+    sMainMenuButtons[idx + 3] = SPAWN_FILE_SELECT_FILE_BUTTON(button, SAVE_FILE_D);
+    sMainMenuButtons[idx + 3]->oMenuButtonScale = MENU_BUTTON_SCALE;
 
     // Return to main menu button
-    sMainMenuButtons[MENU_BUTTON_SCORE_RETURN] =
-        spawn_object_rel_with_rot(scoreButton, MODEL_MAIN_MENU_YELLOW_FILE_BUTTON,
+    sMainMenuButtons[idx + 4] =
+        spawn_object_rel_with_rot(button, MODEL_MAIN_MENU_YELLOW_FILE_BUTTON,
                                   bhvMenuButton,  711, -388, -100, 0x0, -0x8000, 0x0);
-    sMainMenuButtons[MENU_BUTTON_SCORE_RETURN]->oMenuButtonScale = MENU_BUTTON_SCALE;
+    sMainMenuButtons[idx + 4]->oMenuButtonScale = MENU_BUTTON_SCALE;
     // Switch to copy menu button
-    sMainMenuButtons[MENU_BUTTON_SCORE_COPY_FILE] =
-        spawn_object_rel_with_rot(scoreButton, MODEL_MAIN_MENU_BLUE_COPY_BUTTON,
+    sMainMenuButtons[idx + 5] =
+        spawn_object_rel_with_rot(button, selectedButtonID == MENU_BUTTON_SCORE ? MODEL_MAIN_MENU_BLUE_COPY_BUTTON : MODEL_MAIN_MENU_GREEN_SCORE_BUTTON,
                                   bhvMenuButton,    0, -388, -100, 0x0, -0x8000, 0x0);
-    sMainMenuButtons[MENU_BUTTON_SCORE_COPY_FILE]->oMenuButtonScale = MENU_BUTTON_SCALE;
+    sMainMenuButtons[idx + 5]->oMenuButtonScale = MENU_BUTTON_SCALE;
     // Switch to erase menu button
-    sMainMenuButtons[MENU_BUTTON_SCORE_ERASE_FILE] =
-        spawn_object_rel_with_rot(scoreButton, MODEL_MAIN_MENU_RED_ERASE_BUTTON,
+    sMainMenuButtons[idx + 6] =
+        spawn_object_rel_with_rot(button, selectedButtonID == MENU_BUTTON_ERASE ? MODEL_MAIN_MENU_BLUE_COPY_BUTTON : MODEL_MAIN_MENU_RED_ERASE_BUTTON,
                                   bhvMenuButton, -711, -388, -100, 0x0, -0x8000, 0x0);
-    sMainMenuButtons[MENU_BUTTON_SCORE_ERASE_FILE]->oMenuButtonScale = MENU_BUTTON_SCALE;
+    sMainMenuButtons[idx + 6]->oMenuButtonScale = MENU_BUTTON_SCALE;
 }
 
 #define SCORE_TIMER 31
@@ -554,40 +560,6 @@ void check_score_menu_clicked_buttons(struct Object *scoreButton) {
 }
 
 #undef SCORE_TIMER
-
-/**
- * Render buttons for the copy menu.
- * Also check if the save file exists to render a different Mario button.
- */
-void render_copy_menu_buttons(struct Object *copyButton) {
-    // File A
-    sMainMenuButtons[MENU_BUTTON_COPY_FILE_A] = SPAWN_FILE_SELECT_FILE_BUTTON(copyButton, SAVE_FILE_A);
-    sMainMenuButtons[MENU_BUTTON_COPY_FILE_A]->oMenuButtonScale = MENU_BUTTON_SCALE;
-    // File B
-    sMainMenuButtons[MENU_BUTTON_COPY_FILE_B] = SPAWN_FILE_SELECT_FILE_BUTTON(copyButton, SAVE_FILE_B);
-    sMainMenuButtons[MENU_BUTTON_COPY_FILE_B]->oMenuButtonScale = MENU_BUTTON_SCALE;
-    // File C
-    sMainMenuButtons[MENU_BUTTON_COPY_FILE_C] = SPAWN_FILE_SELECT_FILE_BUTTON(copyButton, SAVE_FILE_C);
-    sMainMenuButtons[MENU_BUTTON_COPY_FILE_C]->oMenuButtonScale = MENU_BUTTON_SCALE;
-    // File D
-    sMainMenuButtons[MENU_BUTTON_COPY_FILE_D] = SPAWN_FILE_SELECT_FILE_BUTTON(copyButton, SAVE_FILE_D);
-    sMainMenuButtons[MENU_BUTTON_COPY_FILE_D]->oMenuButtonScale = MENU_BUTTON_SCALE;
-    // Return to main menu button
-    sMainMenuButtons[MENU_BUTTON_COPY_RETURN] =
-        spawn_object_rel_with_rot(copyButton, MODEL_MAIN_MENU_YELLOW_FILE_BUTTON,
-                                  bhvMenuButton,  711, -388, -100, 0x0, -0x8000, 0x0);
-    sMainMenuButtons[MENU_BUTTON_COPY_RETURN]->oMenuButtonScale = MENU_BUTTON_SCALE;
-    // Switch to scire menu button
-    sMainMenuButtons[MENU_BUTTON_COPY_CHECK_SCORE] =
-        spawn_object_rel_with_rot(copyButton, MODEL_MAIN_MENU_GREEN_SCORE_BUTTON,
-                                  bhvMenuButton,    0, -388, -100, 0x0, -0x8000, 0x0);
-    sMainMenuButtons[MENU_BUTTON_COPY_CHECK_SCORE]->oMenuButtonScale = MENU_BUTTON_SCALE;
-    // Switch to erase menu button
-    sMainMenuButtons[MENU_BUTTON_COPY_ERASE_FILE] =
-        spawn_object_rel_with_rot(copyButton, MODEL_MAIN_MENU_RED_ERASE_BUTTON,
-                                  bhvMenuButton, -711, -388, -100, 0x0, -0x8000, 0x0);
-    sMainMenuButtons[MENU_BUTTON_COPY_ERASE_FILE]->oMenuButtonScale = MENU_BUTTON_SCALE;
-}
 
 #define BUZZ_TIMER 21
 
@@ -707,40 +679,6 @@ void check_copy_menu_clicked_buttons(struct Object *copyButton) {
                 MENU_BUTTON_STATE_ZOOM_OUT;
         }
     }
-}
-
-/**
- * Render buttons for the erase menu.
- * Also check if the save file exists to render a different Mario button.
- */
-void render_erase_menu_buttons(struct Object *eraseButton) {
-    // File A
-    sMainMenuButtons[MENU_BUTTON_ERASE_FILE_A] = SPAWN_FILE_SELECT_FILE_BUTTON(eraseButton, SAVE_FILE_A);
-    sMainMenuButtons[MENU_BUTTON_ERASE_FILE_A]->oMenuButtonScale = MENU_BUTTON_SCALE;
-    // File B
-    sMainMenuButtons[MENU_BUTTON_ERASE_FILE_B] = SPAWN_FILE_SELECT_FILE_BUTTON(eraseButton, SAVE_FILE_B);
-    sMainMenuButtons[MENU_BUTTON_ERASE_FILE_B]->oMenuButtonScale = MENU_BUTTON_SCALE;
-    // File C
-    sMainMenuButtons[MENU_BUTTON_ERASE_FILE_C] = SPAWN_FILE_SELECT_FILE_BUTTON(eraseButton, SAVE_FILE_C);
-    sMainMenuButtons[MENU_BUTTON_ERASE_FILE_C]->oMenuButtonScale = MENU_BUTTON_SCALE;
-    // File D
-    sMainMenuButtons[MENU_BUTTON_ERASE_FILE_D] = SPAWN_FILE_SELECT_FILE_BUTTON(eraseButton, SAVE_FILE_D);
-    sMainMenuButtons[MENU_BUTTON_ERASE_FILE_D]->oMenuButtonScale = MENU_BUTTON_SCALE;
-    // Return to main menu button
-    sMainMenuButtons[MENU_BUTTON_ERASE_RETURN] =
-        spawn_object_rel_with_rot(eraseButton, MODEL_MAIN_MENU_YELLOW_FILE_BUTTON,
-                                  bhvMenuButton,  711, -388, -100, 0x0, -0x8000, 0x0);
-    sMainMenuButtons[MENU_BUTTON_ERASE_RETURN]->oMenuButtonScale = MENU_BUTTON_SCALE;
-    // Switch to score menu button
-    sMainMenuButtons[MENU_BUTTON_ERASE_CHECK_SCORE] =
-        spawn_object_rel_with_rot(eraseButton, MODEL_MAIN_MENU_GREEN_SCORE_BUTTON,
-                                  bhvMenuButton,    0, -388, -100, 0x0, -0x8000, 0x0);
-    sMainMenuButtons[MENU_BUTTON_ERASE_CHECK_SCORE]->oMenuButtonScale = MENU_BUTTON_SCALE;
-    // Switch to copy menu button
-    sMainMenuButtons[MENU_BUTTON_ERASE_COPY_FILE] =
-        spawn_object_rel_with_rot(eraseButton, MODEL_MAIN_MENU_BLUE_COPY_BUTTON,
-                                  bhvMenuButton, -711, -388, -100, 0x0, -0x8000, 0x0);
-    sMainMenuButtons[MENU_BUTTON_ERASE_COPY_FILE]->oMenuButtonScale = MENU_BUTTON_SCALE;
 }
 
 /**
@@ -1029,7 +967,7 @@ void load_menu_from_submenu(s16 prevMenuButtonID, s16 selectedButtonID, struct O
         sSelectedButtonID = selectedButtonID;
         play_sound(SOUND_MENU_CAMERA_ZOOM_IN, gGlobalSoundSource);
         sMainMenuButtons[selectedButtonID]->oMenuButtonState = MENU_BUTTON_STATE_GROWING;
-        render_score_menu_buttons(sMainMenuButtons[selectedButtonID]);
+        render_menu_buttons(selectedButtonID);
     }
 }
 
@@ -1114,89 +1052,59 @@ void bhv_menu_button_manager_init(void) {
  * Also play a sound and/or render buttons depending of the button ID selected.
  */
 void check_main_menu_clicked_buttons(void) {
-        // Sound mode menu is handled separately because the button ID for it
-        // is not grouped with the IDs of the other submenus.
-        if (check_clicked_button(sMainMenuButtons[MENU_BUTTON_SOUND_MODE]->oPosX,
-                                 sMainMenuButtons[MENU_BUTTON_SOUND_MODE]->oPosY, 200.0f)) {
-            sMainMenuButtons[MENU_BUTTON_SOUND_MODE]->oMenuButtonState = MENU_BUTTON_STATE_GROWING;
-            sSelectedButtonID = MENU_BUTTON_SOUND_MODE;
-        } else {
-            // Main Menu buttons
-            s8 buttonID;
-            // Configure Main Menu button group
-            for (buttonID = MENU_BUTTON_MAIN_MIN; buttonID < MENU_BUTTON_MAIN_MAX; buttonID++) {
-                s16 buttonX = sMainMenuButtons[buttonID]->oPosX;
-                s16 buttonY = sMainMenuButtons[buttonID]->oPosY;
+    // Sound mode menu is handled separately because the button ID for it
+    // is not grouped with the IDs of the other submenus.
+    if (check_clicked_button(sMainMenuButtons[MENU_BUTTON_SOUND_MODE]->oPosX,
+                                sMainMenuButtons[MENU_BUTTON_SOUND_MODE]->oPosY, 200.0f)) {
+        sMainMenuButtons[MENU_BUTTON_SOUND_MODE]->oMenuButtonState = MENU_BUTTON_STATE_GROWING;
+        sSelectedButtonID = MENU_BUTTON_SOUND_MODE;
+    } else {
+        // Main Menu buttons
+        s8 buttonID;
+        // Configure Main Menu button group
+        for (buttonID = MENU_BUTTON_MAIN_MIN; buttonID < MENU_BUTTON_MAIN_MAX; buttonID++) {
+            s16 buttonX = sMainMenuButtons[buttonID]->oPosX;
+            s16 buttonY = sMainMenuButtons[buttonID]->oPosY;
 
-                if (check_clicked_button(buttonX, buttonY, 200.0f)) {
-                    // If menu button clicked, select it
-                    sMainMenuButtons[buttonID]->oMenuButtonState = MENU_BUTTON_STATE_GROWING;
-                    sSelectedButtonID = buttonID;
-                    break;
-                }
+            if (check_clicked_button(buttonX, buttonY, 200.0f)) {
+                // If menu button clicked, select it
+                sMainMenuButtons[buttonID]->oMenuButtonState = MENU_BUTTON_STATE_GROWING;
+                sSelectedButtonID = buttonID;
+                break;
             }
         }
+    }
 
-        // Play sound of the save file clicked
-        switch (sSelectedButtonID) {
-            case MENU_BUTTON_PLAY_FILE_A:
-                play_sound(SAVE_FILE_SOUND, gGlobalSoundSource);
+    // Play sound of the save file clicked
+    switch (sSelectedButtonID) {
+        case MENU_BUTTON_PLAY_FILE_A:
+        case MENU_BUTTON_PLAY_FILE_B:
+        case MENU_BUTTON_PLAY_FILE_C:
+        case MENU_BUTTON_PLAY_FILE_D:
+            play_sound(SAVE_FILE_SOUND, gGlobalSoundSource);
 #if ENABLE_RUMBLE
-                queue_rumble_data(60, 70);
-                queue_rumble_decay(1);
+            queue_rumble_data(60, 70);
+            queue_rumble_decay(1);
 #endif
-                break;
-            case MENU_BUTTON_PLAY_FILE_B:
-                play_sound(SAVE_FILE_SOUND, gGlobalSoundSource);
+            break;
+        // Play sound of the button clicked and render buttons of that menu.
+        case MENU_BUTTON_SCORE:
+        case MENU_BUTTON_COPY:
+        case MENU_BUTTON_ERASE:
+            play_sound(SOUND_MENU_CAMERA_ZOOM_IN, gGlobalSoundSource);
 #if ENABLE_RUMBLE
-                queue_rumble_data(60, 70);
-                queue_rumble_decay(1);
+            queue_rumble_data(5, 80);
 #endif
-                break;
-            case MENU_BUTTON_PLAY_FILE_C:
-                play_sound(SAVE_FILE_SOUND, gGlobalSoundSource);
+            render_menu_buttons(sSelectedButtonID);
+            break;
+        case MENU_BUTTON_SOUND_MODE:
+            play_sound(SOUND_MENU_CAMERA_ZOOM_IN, gGlobalSoundSource);
 #if ENABLE_RUMBLE
-                queue_rumble_data(60, 70);
-                queue_rumble_decay(1);
+            queue_rumble_data(5, 80);
 #endif
-                break;
-            case MENU_BUTTON_PLAY_FILE_D:
-                play_sound(SAVE_FILE_SOUND, gGlobalSoundSource);
-#if ENABLE_RUMBLE
-                queue_rumble_data(60, 70);
-                queue_rumble_decay(1);
-#endif
-                break;
-            // Play sound of the button clicked and render buttons of that menu.
-            case MENU_BUTTON_SCORE:
-                play_sound(SOUND_MENU_CAMERA_ZOOM_IN, gGlobalSoundSource);
-#if ENABLE_RUMBLE
-                queue_rumble_data(5, 80);
-#endif
-                render_score_menu_buttons(sMainMenuButtons[MENU_BUTTON_SCORE]);
-                break;
-            case MENU_BUTTON_COPY:
-                play_sound(SOUND_MENU_CAMERA_ZOOM_IN, gGlobalSoundSource);
-#if ENABLE_RUMBLE
-                queue_rumble_data(5, 80);
-#endif
-                render_copy_menu_buttons(sMainMenuButtons[MENU_BUTTON_COPY]);
-                break;
-            case MENU_BUTTON_ERASE:
-                play_sound(SOUND_MENU_CAMERA_ZOOM_IN, gGlobalSoundSource);
-#if ENABLE_RUMBLE
-                queue_rumble_data(5, 80);
-#endif
-                render_erase_menu_buttons(sMainMenuButtons[MENU_BUTTON_ERASE]);
-                break;
-            case MENU_BUTTON_SOUND_MODE:
-                play_sound(SOUND_MENU_CAMERA_ZOOM_IN, gGlobalSoundSource);
-#if ENABLE_RUMBLE
-                queue_rumble_data(5, 80);
-#endif
-                render_sound_mode_menu_buttons(sMainMenuButtons[MENU_BUTTON_SOUND_MODE]);
-                break;
-        }
+            render_sound_mode_menu_buttons(sMainMenuButtons[MENU_BUTTON_SOUND_MODE]);
+            break;
+    }
 }
 
 #undef SAVE_FILE_SOUND


### PR DESCRIPTION
Combines `render_score_menu_buttons`, `render_copy_menu_buttons`, and `render_erase_menu_buttons` into one function, so that they can be used properly in `load_menu_from_submenu`.

Fixes #298