### PR TITLE
Fixed hackersm64 using a ucode that never existed

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -25,7 +25,7 @@
                 "TARGET_N64=1",
                 "VERSION_US=1",
                 "F3DEX_GBI_2=1",
-                "F3DZEX_GBI_2=1",
+                "F3DZEX_NON_GBI_2=1",
                 "F3DEX_GBI_SHARED=1",
                 "NON_MATCHING=1",
                 "AVOID_UB=1"

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ else ifeq ($(GRUCODE),l3dex2) # Line3DEX2
 else ifeq ($(GRUCODE),f3dex2pl) # Fast3DEX2_PosLight
   DEFINES += F3DEX2PL_GBI=1 F3DEX_GBI_2=1 F3DEX_GBI_SHARED=1
 else ifeq ($(GRUCODE),f3dzex) # Fast3DZEX (2.08J / Animal Forest - Dōbutsu no Mori)
-  DEFINES += F3DZEX_GBI_2=1 F3DEX_GBI_2=1 F3DEX_GBI_SHARED=1
+  DEFINES += F3DZEX_NON_GBI_2=1 F3DEX_GBI_2=1 F3DEX_GBI_SHARED=1
 else ifeq ($(GRUCODE),super3d) # Super3D
   $(warning Super3D is experimental. Try at your own risk.)
   DEFINES += SUPER3D_GBI=1 F3D_NEW=1

--- a/include/config/config_graphics.h
+++ b/include/config/config_graphics.h
@@ -39,7 +39,7 @@
 // Similar to the above, but 30 FPS (Textures by InTheBeef, cleaned up by Arceveti)
 #define IA8_30FPS_COINS
 
-// Use .rej microcode for certain objects (experimental - only should be used when F3DZEX_GBI_2 is defined).
+// Use .rej microcode for certain objects (experimental - only should be used when F3DEX_GBI_2 is defined).
 // For advanced users only. Does not work perfectly out the box, best used when exported actor models are
 // using 64 vertex sizes, offered by Fast64 in the microcode menu.
 // #define OBJECTS_REJ

--- a/include/config/config_safeguards.h
+++ b/include/config/config_safeguards.h
@@ -14,9 +14,9 @@
  * config_graphics
  */
 
-#ifndef F3DZEX_GBI_2
-    #undef OBJECTS_REJ // OBJECTS_REJ requires f3dzex.
-#endif // !F3DZEX_GBI_2
+#ifndef F3DEX_GBI_2
+    #undef OBJECTS_REJ // OBJECTS_REJ requires f3dex2.
+#endif // !F3DEX_GBI_2
 
 #ifndef F3DEX_GBI_SHARED
     #undef OBJECTS_REJ // Non F3DEX-based ucodes do NOT support ucode switching.

--- a/src/game/game_init.c
+++ b/src/game/game_init.c
@@ -293,6 +293,11 @@ void create_gfx_task_structure(void) {
     gGfxSPTask->task.t.ucode_data = gspF3DZEX2_PosLight_fifoDataStart;
     gGfxSPTask->task.t.ucode_size = ((u8 *) gspF3DZEX2_PosLight_fifoTextEnd - (u8 *) gspF3DZEX2_PosLight_fifoTextStart);
     gGfxSPTask->task.t.ucode_data_size = ((u8 *) gspF3DZEX2_PosLight_fifoDataEnd - (u8 *) gspF3DZEX2_PosLight_fifoDataStart);
+#elif  F3DZEX_NON_GBI_2
+    gGfxSPTask->task.t.ucode = gspF3DZEX2_NoN_PosLight_fifoTextStart;
+    gGfxSPTask->task.t.ucode_data = gspF3DZEX2_NoN_PosLight_fifoDataStart;
+    gGfxSPTask->task.t.ucode_size = ((u8 *) gspF3DZEX2_NoN_PosLight_fifoTextEnd - (u8 *) gspF3DZEX2_NoN_PosLight_fifoTextStart);
+    gGfxSPTask->task.t.ucode_data_size = ((u8 *) gspF3DZEX2_NoN_PosLight_fifoDataEnd - (u8 *) gspF3DZEX2_NoN_PosLight_fifoDataStart);
 #elif   F3DEX2PL_GBI
     gGfxSPTask->task.t.ucode = gspF3DEX2_PosLight_fifoTextStart;
     gGfxSPTask->task.t.ucode_data = gspF3DEX2_PosLight_fifoDataStart;

--- a/src/game/rendering_graph_node.c
+++ b/src/game/rendering_graph_node.c
@@ -367,7 +367,7 @@ void geo_process_master_list_sub(struct GraphNodeMasterList *node) {
         gSPClearGeometryMode(gDisplayListHead++, G_ZBUFFER);
     }
 #ifdef OBJECTS_REJ
- #if defined(F3DZEX_GBI_2) && defined(VISUAL_DEBUG)
+ #if defined(F3DEX_GBI_2) && defined(VISUAL_DEBUG)
     if (hitboxView) render_debug_boxes(DEBUG_UCODE_REJ);
  #endif
     switch_ucode(GRAPH_NODE_UCODE_DEFAULT);
@@ -408,7 +408,7 @@ void geo_append_display_list(void *displayList, s32 layer) {
         }
  #endif // SILHOUETTE
     }
-#endif // F3DZEX_GBI_2 || SILHOUETTE
+#endif // F3DEX_GBI_2 || SILHOUETTE
     if (gCurGraphNodeMasterList != NULL) {
         struct DisplayListNode *listNode =
             alloc_only_pool_alloc(gDisplayListHeap, sizeof(struct DisplayListNode));


### PR DESCRIPTION
This also fixes microcode point lights on Jabo, since it now recognizes the microcode as MM's.