### PR TITLE
Puppyprint color reversion to currEnv + some bugfixes

### DIFF
--- a/src/game/game_init.c
+++ b/src/game/game_init.c
@@ -782,9 +782,13 @@ void thread5_game_loop(UNUSED void *arg) {
 
         audio_game_loop_tick();
         select_gfx_pool();
+#if PUPPYPRINT_DEBUG
         first = osGetTime();
         read_controller_inputs(THREAD_5_GAME_LOOP);
         profiler_update(controllerTime, first);
+#else
+        read_controller_inputs(THREAD_5_GAME_LOOP);
+#endif
         addr = level_script_execute(addr);
 #if !PUPPYPRINT_DEBUG && defined(VISUAL_DEBUG)
         debug_box_input();

--- a/src/game/puppyprint.c
+++ b/src/game/puppyprint.c
@@ -927,8 +927,8 @@ void print_small_text(s32 x, s32 y, const char *str, s32 align, s32 amount, s32 
     textSizeTemp = 1.0f;
     textSizeTotal = textSizeTemp * textSize;
 
-    if (amount == PRINT_ALL) {
-        tx = (signed)strlen(str);
+    if (amount == PRINT_ALL || amount > strLen) {
+        tx = strLen;
     }
 
     gSPDisplayList(gDisplayListHead++, dl_small_text_begin);

--- a/src/game/puppyprint.c
+++ b/src/game/puppyprint.c
@@ -1072,7 +1072,7 @@ s32 text_iterate_command(const char *str, s32 i, s32 runCMD) {
                 s32 col2 = get_hex_value_at_offset(newStr, 15, 2 * j, TRUE) | get_hex_value_at_offset(newStr, 15, (2 * j) + 1, TRUE);
 
                 // Final color value determined by median of two colors + a point in the end-to-end width of the difference between the two colors.
-                // Said point changes is based on the sTimer value in the form of a sine wave, which helps to create the fading effect.
+                // Said point changes based on the sTimer value in the form of a sine wave, which helps to create the fading effect.
                 rgba[j] = ((col1 + col2) / 2) + (s32) (sTimer * ((col1 - col2) / 2));
             }
 

--- a/src/game/puppyprint.c
+++ b/src/game/puppyprint.c
@@ -1078,6 +1078,9 @@ s32 text_iterate_command(const char *str, s32 i, s32 runCMD) {
     s32 lastCharIndex = (signed)strlen(newStr) - 1;
 
     while ((newStr[len] != '>') && (len < lastCharIndex)) len++;
+    if (newStr[len] != '>')
+        return 0;
+
     len++;
 
     // Ignores runCMD, because it's important this is ALWAYS ran.

--- a/src/game/puppyprint.c
+++ b/src/game/puppyprint.c
@@ -414,9 +414,9 @@ extern s16 gVisualSurfaceCount;
 void puppyprint_render_collision(void) {
     char textBytes[200];
 #ifdef PUPPYPRINT_DEBUG_CYCLES
-    sprintf(textBytes, "Collision:<COL_99505099> %dc", collisionTime[NUM_PERF_ITERATIONS]);
+    sprintf(textBytes, "Collision:<COL_FF7F7FFF> %dc", collisionTime[NUM_PERF_ITERATIONS]);
 #else
-    sprintf(textBytes, "Collision:<COL_99505099> %dus", collisionTime[NUM_PERF_ITERATIONS]);
+    sprintf(textBytes, "Collision:<COL_FF7F7FFF> %dus", collisionTime[NUM_PERF_ITERATIONS]);
 #endif
     print_small_text(304, 48, textBytes, PRINT_TEXT_ALIGN_RIGHT, PRINT_ALL, 1);
 
@@ -457,13 +457,12 @@ struct CPUBar {
 extern void print_fps(s32 x, s32 y);
 
 struct CPUBar cpu_ordering_table[] = {
-    { collisionTime, COLOR_RGB_RED,     { "Collision: <COL_99505099>" }},
-    {     graphTime, COLOR_RGB_BLUE,    {     "Graph: <COL_50509999>" }},
-    { behaviourTime, COLOR_RGB_GREEN,   { "Behaviour: <COL_50995099>" }},
-    {     audioTime, COLOR_RGB_YELLOW,  {     "Audio: <COL_99995099>" }},
-    {    cameraTime, COLOR_RGB_CYAN,    {    "Camera: <COL_50999999>" }},
-    {       dmaTime, COLOR_RGB_MAGENTA, {       "DMA: <COL_99509999>" }},
-    { controllerTime, COLOR_RGB_ORANGE, {       "Pad: <COL_99755099>" }},
+    { collisionTime, COLOR_RGB_RED,     { "Collision: <COL_FF7F7FFF>" }},
+    {     graphTime, COLOR_RGB_BLUE,    {     "Graph: <COL_7F7FFFFF>" }},
+    { behaviourTime, COLOR_RGB_GREEN,   { "Behaviour: <COL_7FFF7FFF>" }},
+    {     audioTime, COLOR_RGB_YELLOW,  {     "Audio: <COL_FFFF7FFF>" }},
+    {    cameraTime, COLOR_RGB_CYAN,    {    "Camera: <COL_7FFFFFFF>" }},
+    {       dmaTime, COLOR_RGB_MAGENTA, {       "DMA: <COL_FF7FFFFF>" }},
 };
 
 #define CPU_TABLE_MAX (sizeof(cpu_ordering_table) / sizeof(struct CPUBar))

--- a/src/game/puppyprint.c
+++ b/src/game/puppyprint.c
@@ -1062,17 +1062,16 @@ s32 text_iterate_command(const char *str, s32 i, s32 runCMD) {
             gDPSetEnvColor(gDisplayListHead++, (Color) rgba[0], (Color) rgba[1], (Color) rgba[2], (Color) rgba[3]); // Don't use print_set_envcolour here
         } else if (strncmp((newStr), "<FADE_xxxxxxxx,xxxxxxxx,xx>", 6) == 0) { // Same as above, except it fades between two colours. The third set of numbers is the speed it fades.
             s32 rgba[4];
-            s32 rgba2[4];
 
             // Find transition speed and set timer value
             s32 spd = get_hex_value_at_offset(newStr, 24, 0, FALSE) | get_hex_value_at_offset(newStr, 24, 1, FALSE);
             f32 sTimer = sins(gGlobalTimer * spd * 50);
 
             for (s32 j = 0; j < 4; j++) {
-                rgba[j] = get_hex_value_at_offset(newStr, 6, 2 * j, TRUE) | get_hex_value_at_offset(newStr, 6, (2 * j) + 1, TRUE);
-                rgba2[j] = get_hex_value_at_offset(newStr, 15, 2 * j, TRUE) | get_hex_value_at_offset(newStr, 15, (2 * j) + 1, TRUE);
+                s32 col1 = get_hex_value_at_offset(newStr, 6, 2 * j, TRUE) | get_hex_value_at_offset(newStr, 6, (2 * j) + 1, TRUE);
+                s32 col2 = get_hex_value_at_offset(newStr, 15, 2 * j, TRUE) | get_hex_value_at_offset(newStr, 15, (2 * j) + 1, TRUE);
 
-                rgba[j] = ((rgba[j] + rgba2[j]) / 2) + (s32) (sTimer * ((rgba[j] - rgba2[j]) / 2));
+                rgba[j] = ((col1 + col2) / 2) + (s32) (sTimer * ((col1 - col2) / 2));
             }
 
             rainbowToggle = 0;

--- a/src/game/puppyprint.c
+++ b/src/game/puppyprint.c
@@ -1071,6 +1071,8 @@ s32 text_iterate_command(const char *str, s32 i, s32 runCMD) {
                 s32 col1 = get_hex_value_at_offset(newStr, 6, 2 * j, TRUE) | get_hex_value_at_offset(newStr, 6, (2 * j) + 1, TRUE);
                 s32 col2 = get_hex_value_at_offset(newStr, 15, 2 * j, TRUE) | get_hex_value_at_offset(newStr, 15, (2 * j) + 1, TRUE);
 
+                // Final color value determined by median of two colors + a point in the end-to-end width of the difference between the two colors.
+                // Said point changes is based on the sTimer value in the form of a sine wave, which helps to create the fading effect.
                 rgba[j] = ((col1 + col2) / 2) + (s32) (sTimer * ((col1 - col2) / 2));
             }
 


### PR DESCRIPTION
- Invalid hexadecimal syntax for hexadecimal color values will revert the invalid elements back to using the currEnv color. This can be done intentionally if you want certain elements of the currEnv to come back after setting a color such as alpha.
  - Example 1: `<COL_-------->` will revert the entire color to match currEnv.
  - Example 2: `<COL_FF0000-->` will set the string color to red, while retaining currEnv's alpha color.
  - Example 3: `<FADE_FF0000FF,--------,20>` will fade between red and the currEnv color.
  - Example 4: `<COL_WWXXYYZZ>` is functionally no different than `<COL_-------->`.
- Lowercase hexadecimal now also supported.
- Various small bugfixes and some updates to comments