### PR TITLE
reset adjacent rooms when loading a new area

### DIFF
--- a/src/game/area.c
+++ b/src/game/area.c
@@ -242,6 +242,10 @@ void load_area(s32 index) {
 
         gMarioCurrentRoom = 0;
 
+        if (gCurrentArea->surfaceRooms != NULL) {
+            bzero(gDoorAdjacentRooms, sizeof(gDoorAdjacentRooms));
+        }
+
         if (gCurrentArea->terrainData != NULL) {
             load_area_terrain(index, gCurrentArea->terrainData, gCurrentArea->surfaceRooms,
                               gCurrentArea->macroObjects);


### PR DESCRIPTION
PRing to develop/2.1.0 only because its the only dev branch and I think this could use some _deep_ testing with vanilla.

The reason why is that there is a chance that vanilla could have depended on this bug in levels that have rooms is because adjacent rooms were never reset. Doors set adjacent rooms like this:

![image](https://github.com/HackerN64/HackerSM64/assets/79979276/adb91557-2344-4cba-a6c2-481c8e6d26c6)

It is a pretty strict requirement if you look at the highlighted area, adjacent is only set if the doors room isnt the same as its forward and backward one. So there is a chance that a level could accidentally rely on Area 1 setting adjacent rooms, then Area 2 using those to keep certain objects rendering.

So although this shouldn't go into 2.1, its worth keeping a record of this and discussing what we could do and what side effects it could cause.

Fixes #703 (maybe)