### PR TITLE
Fix lighting engine by removing duplicate setup_global_light call

### DIFF
--- a/src/game/rendering_graph_node.c
+++ b/src/game/rendering_graph_node.c
@@ -857,7 +857,6 @@ void geo_process_camera(struct GraphNodeCamera *node) {
     guMtxF2L(gCameraTransform, viewMtx);
 #endif
     gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(viewMtx), G_MTX_PROJECTION | G_MTX_MUL | G_MTX_NOPUSH);
-    setup_global_light();
 
     if (node->fnNode.node.children != 0) {
         gCurGraphNodeCamera = node;


### PR DESCRIPTION
This function was erroneously being called twice, which caused the directional light color to break, but the direction still worked, which was confusing. I removed the duplicate call. Here is Wiseguy's explanation of the issue:

This is supposed to only be called in the game loop, before reading the controller inputs, so that it's one of the first things in the frame, thus allowing one to set the directional lighting almost anywhere in the code with no issue. But the duplicate call was resetting the global light color. 