### PR TITLE
Clamp constant falloff to 8 minimum to prevent overflow

### DIFF
--- a/src/engine/behavior_script.c
+++ b/src/engine/behavior_script.c
@@ -770,13 +770,13 @@ static s32 bhv_cmd_set_light_color(void) {
 // Command 0x39: Sets an object's light falloff
 // Usage: SET_LIGHT_FALLOFF(constant, linear, quadratic)
 static s32 bhv_cmd_set_light_falloff(void) {
-    s32 constantFalloff = BHV_CMD_GET_2ND_S16(0);
-    s32 linearFalloff = BHV_CMD_GET_1ST_S16(1);
-    s32 quadraticFalloff = BHV_CMD_GET_2ND_S16(1);
+    u32 constantFalloff = BHV_CMD_GET_2ND_S16(0);
+    u32 linearFalloff = BHV_CMD_GET_1ST_S16(1);
+    u32 quadraticFalloff = BHV_CMD_GET_2ND_S16(1);
 
     gCurrentObject->oLightQuadraticFalloff = quadraticFalloff;
     gCurrentObject->oLightLinearFalloff = linearFalloff;
-    gCurrentObject->oLightConstantFalloff = constantFalloff;
+    gCurrentObject->oLightConstantFalloff = MAX(constantFalloff, 8U);
 
     gCurBhvCommand += 2;
     return BHV_PROC_CONTINUE;

--- a/src/game/rendering_graph_node.c
+++ b/src/game/rendering_graph_node.c
@@ -775,7 +775,7 @@ void emit_light(Vec3f pos, s32 red, s32 green, s32 blue, u32 quadraticFalloff, u
     gPointLights[gPointLightCount].l.pl.colc[0] = gPointLights[gPointLightCount].l.pl.col[0] = red;
     gPointLights[gPointLightCount].l.pl.colc[1] = gPointLights[gPointLightCount].l.pl.col[1] = green;
     gPointLights[gPointLightCount].l.pl.colc[2] = gPointLights[gPointLightCount].l.pl.col[2] = blue;
-    gPointLights[gPointLightCount].l.pl.constant_attenuation = (constantFalloff == 0) ? 8 : constantFalloff;
+    gPointLights[gPointLightCount].l.pl.constant_attenuation = MAX(constantFalloff, 8U);
     gPointLights[gPointLightCount].l.pl.linear_attenuation = linearFalloff;
     gPointLights[gPointLightCount].l.pl.quadratic_attenuation = quadraticFalloff;
     gPointLights[gPointLightCount].worldPos[0] = pos[0];
@@ -1507,7 +1507,7 @@ void geo_process_scene_light(struct GraphNodeSceneLight *node)
 
             node->light->l.pl.quadratic_attenuation = node->a;
             node->light->l.pl.linear_attenuation = node->b;
-            node->light->l.pl.constant_attenuation = (node->c == 0) ? 8 : node->c;
+            node->light->l.pl.constant_attenuation = MAX(node->c, 8U);
             break;
         case LIGHT_TYPE_AMBIENT:
             if (!gOverrideAmbientLight)


### PR DESCRIPTION
Due to a microcode limitation, constant falloff can't be less than 8 or it will overflow, causing point lights to break when they get close to vertices. lighting engine was checking if constant falloff was set to 0 and setting it to 8 if so, but it was not checking if it was between 1 and 7. This PR fixes that. 