### PR TITLE
Check for opensuse's cross mips gcc package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -448,6 +448,8 @@ else ifneq ($(call find-command,mips64-none-elf-ld),)
   CROSS := mips64-none-elf-
 else ifneq ($(call find-command,mips-ld),)
   CROSS := mips-
+else ifneq ($(call find-command,mips-suse-linux-ld ),)
+  CROSS := mips-suse-linux-
 else
   $(error Unable to detect a suitable MIPS toolchain installed)
 endif


### PR DESCRIPTION
Makes it possible to rely on the official repo.
Ideally the following instructions would also be added to the wiki for opensuse: 
```
sudo zypper install cross-mips-binutils git capstone pkgconf python311 cross-mips-gcc14 
# install packages under devel_basis, equivalent to build-essential in deb 
sudo zypper install --type pattern devel_basis
```