### PR TITLE
Place stack canaries behind `DEBUG_ASSERTIONS` instead of `DEBUG`

### DIFF
--- a/src/boot/main.c
+++ b/src/boot/main.c
@@ -320,7 +320,7 @@ void alert_rcp_hung_up(void) {
  * Increment the first and last values of the stack.
  * If they're different, that means an error has occured, so trigger a crash.
 */
-#ifdef DEBUG
+#ifdef DEBUG_ASSERTIONS
 void check_stack_validity(void) {
     gIdleThreadStack[0]++;
     gIdleThreadStack[THREAD1_STACK - 1]++;
@@ -379,7 +379,7 @@ void thread3_main(UNUSED void *arg) {
     } else {
         gBorderHeight = BORDER_HEIGHT_CONSOLE;
     }
-#ifdef DEBUG
+#ifdef DEBUG_ASSERTIONS
     gIdleThreadStack[0] = 0;
     gIdleThreadStack[THREAD1_STACK - 1] = 0;
     gThread3Stack[0] = 0;
@@ -403,7 +403,7 @@ void thread3_main(UNUSED void *arg) {
     while (TRUE) {
         OSMesg msg;
         osRecvMesg(&gIntrMesgQueue, &msg, OS_MESG_BLOCK);
-#ifdef DEBUG
+#ifdef DEBUG_ASSERTIONS
         check_stack_validity();
 #endif
         switch ((uintptr_t) msg) {


### PR DESCRIPTION
These were missed when `DEBUG_ASSERTIONS` was introduced.