### PR TITLE
Bugfix (Vanilla): Warping to cake screen in area other than Area 1 crashes the game

### DIFF
--- a/src/game/area.c
+++ b/src/game/area.c
@@ -231,6 +231,7 @@ void clear_area_graph_nodes(void) {
 void load_area(s32 index) {
     if (gCurrentArea == NULL && gAreaData[index].graphNode != NULL) {
         gCurrentArea = &gAreaData[index];
+        gMarioState->area = gCurrentArea;
         gCurrAreaIndex = gCurrentArea->index;
         main_pool_pop_state();
         main_pool_push_state();


### PR DESCRIPTION
~~This also simultaneously fixes same-area exit course crashes, although that has already been dealt with by enforcing level warps (which is probably the preferred solution anyway).~~

EDIT: Nevermind, apparently that was already working...........when did that get fixed?