### PR TITLE
README: Link to SM64 build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,4 +210,4 @@ A: Theoretically, all yes.
 
 ## Installation help
 
-Go read the original SM64 repo README.md
+Follow the build instructions from [the original SM64 decompilation's README.md](https://github.com/n64decomp/sm64/blob/master/README.md) with the extra step of running `sudo apt install gcc-mips-linux-gnu` before building HackerSM64.


### PR DESCRIPTION
Link to the mentioned SM64 decomplication's readme for instructions on how to build HackerSM64. Also re-mention of needing to install GCC, since it isn't mentioned in the SM64 decomp build instructions. (I fully admit to missing this step when building HackerSM64 for the first time)