### PR TITLE
Add support for realtime clock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,6 +265,14 @@ ifeq ($(LIBPL),1)
   SRC_DIRS += $(LIBPL_DIR)
 endif
 
+# USE_RTC - whether to support the realtime clock and include librtc or not
+USE_RTC ?= 0
+$(eval $(call validate-option,USE_RTC,0 1))
+ifeq ($(USE_RTC),1)
+  DEFINES += USE_RTC=1
+  SRC_DIRS += lib/librtc
+endif
+
 BUILD_DIR_BASE := build
 # BUILD_DIR is the location where all build artifacts are placed
 BUILD_DIR      := $(BUILD_DIR_BASE)/$(VERSION)_$(CONSOLE)

--- a/Makefile
+++ b/Makefile
@@ -265,14 +265,6 @@ ifeq ($(LIBPL),1)
   SRC_DIRS += $(LIBPL_DIR)
 endif
 
-# USE_RTC - whether to support the realtime clock and include librtc or not
-USE_RTC ?= 0
-$(eval $(call validate-option,USE_RTC,0 1))
-ifeq ($(USE_RTC),1)
-  DEFINES += USE_RTC=1
-  SRC_DIRS += lib/librtc
-endif
-
 BUILD_DIR_BASE := build
 # BUILD_DIR is the location where all build artifacts are placed
 BUILD_DIR      := $(BUILD_DIR_BASE)/$(VERSION)_$(CONSOLE)
@@ -391,7 +383,7 @@ LEVEL_DIRS     := $(patsubst levels/%,%,$(dir $(wildcard levels/*/header.h)))
 VNL_ACTRS_DIRS := $(patsubst actors/vanilla_actors/%,%,$(dir $(wildcard actors/vanilla_actors/*/header.h)))
 
 # Directories containing source files
-SRC_DIRS += src src/boot src/game src/engine src/audio src/menu src/buffers actors levels bin data assets asm lib sound
+SRC_DIRS += src src/boot src/game src/engine src/audio src/menu src/buffers lib/librtc actors levels bin data assets asm lib sound
 LIBZ_SRC_DIRS := src/libz
 GODDARD_SRC_DIRS := src/goddard src/goddard/dynlists
 BIN_DIRS := bin bin/$(VERSION)

--- a/asm/rom_header.s
+++ b/asm/rom_header.s
@@ -22,7 +22,7 @@
 .word  0x00000000               /* Unknown */
 #endif
 .word  0x0000004E               /* Cartridge */
-#if defined(EEP4K) && !defined(EMU_DEFAULT_TO_GCN)
+#if defined(EEP4K) && !defined(EMU_DEFAULT_TO_GCN) && !defined(USE_RTC)
 .ascii "SM"                     /* Cartridge ID */
 #else
 .ascii "ED"                     /* Cartridge ID */
@@ -35,14 +35,35 @@
     .ascii "E"                  /* NTSC-U (North America) */
 #endif
 
+/* Savetype, region, and RTC */
 #if defined(SRAM)
-    .byte  0x32                 /* Version */
+    #if defined(USE_RTC)
+    .byte  0x33
+    #else
+    .byte  0x32
+    #endif
 #elif defined(EEP16K)
-    .byte  0x22                 /* Version */
+    #if defined(USE_RTC)
+    .byte  0x23
+    #else
+    .byte  0x22
+    #endif
 #elif defined(SRAM768K)
-    .byte  0x42                 /* Version */
+    #if defined(USE_RTC)
+    .byte  0x43
+    #else
+    .byte  0x42
+    #endif
 #elif defined(FLASHRAM)
-    .byte  0x52                 /* Version */
+    #if defined(USE_RTC)
+    .byte  0x53
+    #else
+    .byte  0x52
+    #endif
 #else
-    .byte  0x12                 /* Version */
+    #if defined(USE_RTC)
+    .byte  0x13
+    #else
+    .byte  0x12
+    #endif
 #endif

--- a/asm/rom_header.s
+++ b/asm/rom_header.s
@@ -35,35 +35,21 @@
     .ascii "E"                  /* NTSC-U (North America) */
 #endif
 
+#if defined(USE_RTC)
+    #define RTC_BIT 0x1
+#else
+    #define RTC_BIT 0x0
+#endif
+
 /* Savetype, region, and RTC */
 #if defined(SRAM)
-    #if defined(USE_RTC)
-    .byte  0x33
-    #else
-    .byte  0x32
-    #endif
+    .byte  0x32 | RTC_BIT
 #elif defined(EEP16K)
-    #if defined(USE_RTC)
-    .byte  0x23
-    #else
-    .byte  0x22
-    #endif
+    .byte  0x22 | RTC_BIT
 #elif defined(SRAM768K)
-    #if defined(USE_RTC)
-    .byte  0x43
-    #else
-    .byte  0x42
-    #endif
+    .byte  0x42 | RTC_BIT
 #elif defined(FLASHRAM)
-    #if defined(USE_RTC)
-    .byte  0x53
-    #else
-    .byte  0x52
-    #endif
+    .byte  0x52 | RTC_BIT
 #else
-    #if defined(USE_RTC)
-    .byte  0x13
-    #else
-    .byte  0x12
-    #endif
+    .byte  0x12 | RTC_BIT
 #endif

--- a/include/config/config_rom.h
+++ b/include/config/config_rom.h
@@ -11,6 +11,12 @@
 #define INTERNAL_ROM_NAME "HackerSM64          "
 
 /**
+ * Enable the realtime clock (RTC)
+ * See lib/librtc/librtc.h for RTC related functions
+ */
+// #define USE_RTC
+
+/**
  * Force the game to delete any existing save data originating from a different hack. This requires INTERNAL_ROM_NAME to be unique to work properly.
  * It is recommended to enable this if any significant changes to the save file are made that could cause issues with this or other hacks.
  * NOTE: Using save editors with this define will likely just end up wiping your save, since SM64 specific save editors most likely use hardcoded save magic.

--- a/lib/librtc/librtc.c
+++ b/lib/librtc/librtc.c
@@ -84,7 +84,7 @@ typedef enum {
 	LIBRTC_READY = LIBRTC_INIT_CALLED | LIBRTC_NOT_WAITING
 } librtc_state_t;
 
-static librtc_state_t s_rtc_state;
+static librtc_state_t s_rtc_state = 0;
 static long long s_wait_start;
 static long long s_wait_end;
 
@@ -151,22 +151,22 @@ static void librtc_send_cmd() {
 	__builtin_mips_cache( 0x19, &s_si_buffer[8] );
 	__builtin_mips_cache( 0x19, &s_si_buffer[12] );
 
-	*((volatile unsigned int*)0xa4800000u) = (unsigned int)s_si_buffer;
+	*((volatile unsigned int*)0xa4800000u) = (unsigned int)s_si_buffer & 0x1FFFFFFFu;
 	asm volatile( "":::"memory" );
 	*((volatile unsigned int*)0xa4800010u) = 0x1fc007c0u;
 	asm volatile( "":::"memory" );
 
 	si_await_op();
 
+	*((volatile unsigned int*)0xa4800000u) = (unsigned int)s_si_buffer & 0x1FFFFFFFu;
+	asm volatile( "":::"memory" );
+	*((volatile unsigned int*)0xa4800004u) = 0x1fc007c0u;
+	asm volatile( "":::"memory" );
+
 	__builtin_mips_cache( 0x11, &s_si_buffer[0] );
 	__builtin_mips_cache( 0x11, &s_si_buffer[4] );
 	__builtin_mips_cache( 0x11, &s_si_buffer[8] );
 	__builtin_mips_cache( 0x11, &s_si_buffer[12] );
-
-	*((volatile unsigned int*)0xa4800000u) = (unsigned int)s_si_buffer;
-	asm volatile( "":::"memory" );
-	*((volatile unsigned int*)0xa4800004u) = 0x1fc007c0u;
-	asm volatile( "":::"memory" );
 
 	si_await_op();
 }
@@ -272,25 +272,6 @@ librtc_bool librtc_init() {
 		return s_rtc_state != LIBRTC_READY;
 	}
 
-	const librtc_bool isEmulator = librtc_is_emulator();
-	if( isEmulator ) {
-		// Check for Project 64 specifically. This emulator has a major bug that causes all controller inputs to stop working if
-		// attempting to initialize the RTC after the controllers, so we should avoid attempting to interface with the RTC at all
-		// on Project 64. (Project 64 doesn't support RTC anyway) This bug is present on all versions of PJ64 so far.
-		// No other emulator has this bug, and it is safe on console. It's just yet another PJ64 bug.
-
-		// This is one of the few PJ64 checks that doesn't result in PJ64 halting, crashing, or breaking input
-		if(
-			*((const volatile unsigned int*)0xbfd00104) == 0x01040104u && // expected behaviour
-			*((const volatile unsigned short*)0xbfd00106) == 0u // PJ64 specific behaviour
-		) {
-			s_rtc_state = LIBRTC_READY;
-			librtc_set_interrupts( intr );
-			return false;
-		}
-	}
-
-
 	si_wait_safe( intr );
 	s_rtc_state |= LIBRTC_INIT_CALLED;
 
@@ -304,7 +285,7 @@ librtc_bool librtc_init() {
 	s_wait_start = librtc_clock();
 	s_wait_end = s_wait_start + (LIBRTC_CLOCKS_PER_SEC / 50u);
 
-	if( isEmulator ) {
+	if( librtc_is_emulator() ) {
 		s_rtc_state |= LIBRTC_NOT_WAITING;
 	}
 

--- a/lib/librtc/librtc.c
+++ b/lib/librtc/librtc.c
@@ -109,6 +109,7 @@ static long long s_wait_start;
 static long long s_wait_end;
 
 static long long s_offset = 0ll;
+static int s_tod_offset = 0;
 
 __attribute__((always_inline))
 static inline void librtc_copy( librtc_time *dest, const librtc_time *src ) {
@@ -379,12 +380,14 @@ librtc_bool librtc_get_time_raw( librtc_time *tm ) {
 
 void librtc_set_offset( long long offset ) {
 	s_offset = offset;
+	s_tod_offset = (int)(offset % LIBRTC_SECONDS_IN_DAY);
 }
 
 long long librtc_set_time( const librtc_time *now ) {
 	librtc_time epoch;
 	if( librtc_get_time_raw( &epoch ) ) {
 		s_offset = librtc_time_diff( &epoch, now );
+		s_tod_offset = (int)(s_offset % LIBRTC_SECONDS_IN_DAY);
 	}
 
 	return s_offset;
@@ -474,6 +477,25 @@ librtc_bool librtc_from_unix_time( long long unixTime, librtc_time *tm ) {
 	if( tm->tm_wday < 0 ) tm->tm_wday += 7;
 
 	return true;
+}
+
+int librtc_get_time_of_day() {
+	librtc_time tm;
+	if( !librtc_get_time_raw( &tm ) ) {
+		return -1;
+	}
+
+	librtc_register int seconds = tm.tm_sec;
+	seconds += tm.tm_min * (int)LIBRTC_SECONDS_IN_MINUTE;
+	seconds += tm.tm_hour * (int)LIBRTC_SECONDS_IN_HOUR;
+	seconds += s_tod_offset;
+
+	seconds %= (int)LIBRTC_SECONDS_IN_DAY;
+	if( seconds < 0 ) {
+		seconds = (int)LIBRTC_SECONDS_IN_DAY - seconds;
+	}
+
+	return seconds;
 }
 
 static inline librtc_bool strftime_push_text( char *str, unsigned int *i, unsigned int count, const char *text ) {

--- a/lib/librtc/librtc.c
+++ b/lib/librtc/librtc.c
@@ -12,6 +12,11 @@
  * compiled binary, for any purpose, commercial or non-commercial, and by any means.
  */
 
+// <HackerSM64>
+#include "config/config_rom.h"
+#ifdef USE_RTC
+// </HackerSM64>
+
 #include "librtc.h"
 
 #ifdef __cplusplus
@@ -720,3 +725,7 @@ unsigned int librtc_strftime( char *str, unsigned int count, const char *format,
 	str[count - 1] = '\0';
 	return librtc_strftime_internal( str, count, format, &tm );
 }
+
+// <HackerSM64>
+#endif
+// </HackerSM64>

--- a/lib/librtc/librtc.c
+++ b/lib/librtc/librtc.c
@@ -2,9 +2,6 @@
  * by Matt "falcobuster" Pharoah
  * https://gitlab.com/mpharoah/librtc
  *
- * The proper 64 byte RTC commands needed to interface with the RTC were taken from libdragon
- * (https://github.com/DragonMinded/libdragon)
- *
  * Public Domain (www.unlicense.org)
  * This is free and unencumbered software released into the public domain.
  *
@@ -74,25 +71,8 @@ static const int s_yday_table[12] = {
 	0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334
 };
 
-static const unsigned int SI_GET_RTC_TIME_CMD[16] = {
-	0u, 0x02090702u, 0xffffffffu, 0xffffffffu, 0xfffe0000u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u ,0u ,0u, 1u
-};
-
-static const unsigned int SI_GET_RTC_STATUS_CMD[16] = {
-	0u, 0xff010306u, 0xfffffffeu, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u ,0u ,0u, 1u
-};
-
-static const unsigned int SI_GET_RTC_CTRL_CMD[16] = {
-	0u, 0x02090700u, 0xffffffffu, 0xffffffffu, 0xfffe0000u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u ,0u ,0u, 1u
-};
-
-static const unsigned int SI_SET_RTC_CTRL_CMD_TEMPLATE[16] = {
-	0u, 0x0a010800u, 0x03000000u, 0u, 0xfffe0000u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u ,0u ,0u, 1u
-};
-
-static const unsigned int SI_REENABLE_CONTROLLERS_CMD[16] = {
-	0xff010401u, 0xffffffffu, 0xff010401u, 0xffffffffu, 0xff010401u, 0xffffffffu, 0xff010401u, 0xffffffffu, 0xfe000000u, 0u, 0u, 0u, 0u, 0u, 0u, 1u
-};
+#define LIBRTC_GET_TIME_CMD 0x020907u
+#define LIBRTC_GET_STATUS_CMD 0x010306u
 
 static unsigned int s_si_buffer[16] __attribute__((aligned(16)));
 
@@ -165,11 +145,7 @@ static inline void __attribute__((always_inline)) si_wait_safe( librtc_bool yiel
 	}
 }
 
-static void librtc_exec( const unsigned int *cmd ) {
-	for( int i = 0; i < 16; i++ ) {
-		s_si_buffer[i] = cmd[i];
-	}
-
+static void librtc_send_cmd() {
 	__builtin_mips_cache( 0x19, &s_si_buffer[0] );
 	__builtin_mips_cache( 0x19, &s_si_buffer[4] );
 	__builtin_mips_cache( 0x19, &s_si_buffer[8] );
@@ -193,6 +169,34 @@ static void librtc_exec( const unsigned int *cmd ) {
 	asm volatile( "":::"memory" );
 
 	si_await_op();
+}
+
+static void librtc_exec( unsigned int cmd, unsigned char arg, unsigned int unk ) {
+	s_si_buffer[0] = 0u;
+	s_si_buffer[1] = (cmd << 8) | (unsigned int)arg;
+	s_si_buffer[2] = 0xFFFFFFFFu;
+	s_si_buffer[3] = 0xFFFFFFFFu;
+	s_si_buffer[4] = unk;
+	for( int i = 5; i < 15; i++ ) {
+		s_si_buffer[i] = 0u;
+	}
+	s_si_buffer[15] = 1u;
+
+	librtc_send_cmd();
+}
+
+static void librtc_done() {
+	for( int i = 0; i < 8; ) {
+		s_si_buffer[i++] = 0xff010401u;
+		s_si_buffer[i++] = 0xffffffffu;
+	}
+	s_si_buffer[8] = 0xfe000000u;
+	for( int i = 9; i < 15; i++ ) {
+		s_si_buffer[i] = 0u;
+	}
+	s_si_buffer[15] = 1u;
+
+	librtc_send_cmd();
 }
 
 static inline unsigned char decode_rtc_byte( unsigned char x ) {
@@ -286,27 +290,17 @@ librtc_bool librtc_init() {
 		}
 	}
 
+
 	si_wait_safe( intr );
 	s_rtc_state |= LIBRTC_INIT_CALLED;
 
-	librtc_exec( SI_GET_RTC_STATUS_CMD );
-	if( s_si_buffer[3] || (s_si_buffer[2] >> 8) != 0x1000u ) {
-		librtc_exec( SI_REENABLE_CONTROLLERS_CMD );
+	librtc_exec( LIBRTC_GET_STATUS_CMD, 0, 0u );
+	if( (s_si_buffer[1] & 0xFFu) || (s_si_buffer[2] >> 16) != 0x1000u ) {
 		librtc_set_interrupts( intr );
 		return false;
 	}
 
 	s_rtc_state |= LIBRTC_GOOD;
-	librtc_exec( SI_GET_RTC_CTRL_CMD );
-
-	unsigned int cmd[16];
-	for( int i = 0; i < 16; i++ ) {
-		cmd[i] = SI_SET_RTC_CTRL_CMD_TEMPLATE[i];
-	}
-	cmd[3] = s_si_buffer[3];
-
-	librtc_exec( cmd );
-
 	s_wait_start = librtc_clock();
 	s_wait_end = s_wait_start + (LIBRTC_CLOCKS_PER_SEC / 50u);
 
@@ -314,7 +308,7 @@ librtc_bool librtc_init() {
 		s_rtc_state |= LIBRTC_NOT_WAITING;
 	}
 
-	librtc_exec( SI_REENABLE_CONTROLLERS_CMD );
+	librtc_done();
 	librtc_set_interrupts( intr );
 	return true;
 }
@@ -357,7 +351,7 @@ librtc_bool librtc_get_time_raw( librtc_time *tm ) {
 	const librtc_bool intr = librtc_set_interrupts( false );
 	si_wait_safe( intr );
 
-	librtc_exec( SI_GET_RTC_TIME_CMD );
+	librtc_exec( LIBRTC_GET_TIME_CMD, 2, 0x80fe0000u );
 	const unsigned char *const data = (const unsigned char*)&s_si_buffer[2];
 	tm->tm_sec = (int)decode_rtc_byte( data[0] );
 	tm->tm_min = (int)decode_rtc_byte( data[1] );
@@ -373,7 +367,7 @@ librtc_bool librtc_get_time_raw( librtc_time *tm ) {
 		tm->tm_yday++;
 	}
 
-	librtc_exec( SI_REENABLE_CONTROLLERS_CMD );
+	librtc_done();
 	librtc_set_interrupts( intr );
 	return true;
 }
@@ -441,7 +435,7 @@ librtc_bool librtc_from_unix_time( long long unixTime, librtc_time *tm ) {
 		tm->tm_hour = 0;
 		tm->tm_mday = 1;
 		tm->tm_mon = 0;
-		tm->tm_year = -0x80000000;
+		tm->tm_year = -0x8FFFFFFF;
 		tm->tm_wday = 4;
 		tm->tm_yday = 0;
 		return false;

--- a/lib/librtc/librtc.c
+++ b/lib/librtc/librtc.c
@@ -438,7 +438,7 @@ librtc_bool librtc_from_unix_time( long long unixTime, librtc_time *tm ) {
 		tm->tm_hour = 0;
 		tm->tm_mday = 1;
 		tm->tm_mon = 0;
-		tm->tm_year = -0x8FFFFFFF;
+		tm->tm_year = -0x80000000;
 		tm->tm_wday = 4;
 		tm->tm_yday = 0;
 		return false;

--- a/lib/librtc/librtc.c
+++ b/lib/librtc/librtc.c
@@ -72,7 +72,7 @@ static const int s_yday_table[12] = {
 };
 
 static unsigned int s_si_buffer[16] __attribute__((aligned(16)));
-static volatile unsigned int s_si_backup[16] __attribute__((aligned(16)));
+static unsigned int s_si_backup[16] __attribute__((aligned(16)));
 static unsigned int s_prev_dma_addr;
 
 typedef enum {
@@ -162,7 +162,9 @@ static void librtc_pif_save() {
 	for( int i = 0; i < 16; i++ ) {
 		s_si_backup[i] = si_pif_ram[i];
 	}
+}
 
+static void librtc_pif_restore() {
 	if( s_exec_on_write_bug ) {
 		// The emulator incorrectly executes the joybus on a DMA write instead of a read
 		// Clear the command register so it doesn't execute again
@@ -171,9 +173,7 @@ static void librtc_pif_save() {
 		// Re-parse the stored PIF RAM state
 		s_si_backup[15] |= 1u;
 	}
-}
 
-static void librtc_pif_restore() {
 	__builtin_mips_cache( 0x19, &s_si_backup[0] );
 	__builtin_mips_cache( 0x19, &s_si_backup[4] );
 	__builtin_mips_cache( 0x19, &s_si_backup[8] );

--- a/lib/librtc/librtc.c
+++ b/lib/librtc/librtc.c
@@ -151,33 +151,6 @@ static inline void __attribute__((always_inline)) si_wait_safe( librtc_bool yiel
 	}
 }
 
-__attribute__((always_inline))
-static inline void librtc_sanitize_saved_pif_ram() {
-	unsigned char *p = (unsigned char*)s_si_backup;
-	unsigned char *const end = p + 63;
-
-	while( p < end ) {
-		const unsigned char tx = *p;
-		if( tx == 0xfe ) break;
-
-		if( tx == 0 || tx >= 0xfd ) {
-			p++;
-			continue;
-		}
-
-		p++;
-
-		if( p >= end ) break;
-		*p &= 0x3f; // clear response status flags from output length byte
-
-		p += *p;
-		p += tx;
-		p++;
-	}
-
-	*end |= 1; // allow joybus to re-parse the command buffer
-}
-
 static void librtc_pif_save() {
 	s_prev_dma_addr = *((volatile unsigned int*)0xa4800000u);
 
@@ -195,8 +168,8 @@ static void librtc_pif_save() {
 		// Clear the command register so it doesn't execute again
 		s_si_backup[15] &= 0xffffff00u;
 	} else {
-		asm volatile( "":::"memory" );
-		librtc_sanitize_saved_pif_ram();
+		// Re-parse the stored PIF RAM state
+		s_si_backup[15] |= 1u;
 	}
 }
 

--- a/lib/librtc/librtc.c
+++ b/lib/librtc/librtc.c
@@ -90,6 +90,8 @@ static long long s_wait_end;
 static long long s_offset = 0ll;
 static int s_tod_offset = 0;
 
+static librtc_bool s_exec_on_write_bug = false;
+
 __attribute__((always_inline))
 static inline void librtc_zero_words( unsigned int *addr, unsigned int numWords ) {
 	for( unsigned int i = 0; i < numWords; i++ ) addr[i] = 0u;
@@ -149,6 +151,33 @@ static inline void __attribute__((always_inline)) si_wait_safe( librtc_bool yiel
 	}
 }
 
+__attribute__((always_inline))
+static inline void librtc_sanitize_saved_pif_ram() {
+	unsigned char *p = (unsigned char*)s_si_backup;
+	unsigned char *const end = p + 63;
+
+	while( p < end ) {
+		const unsigned char tx = *p;
+		if( tx == 0xfe ) break;
+
+		if( tx == 0 || tx >= 0xfd ) {
+			p++;
+			continue;
+		}
+
+		p++;
+
+		if( p >= end ) break;
+		*p &= 0x3f; // clear response status flags from output length byte
+
+		p += *p;
+		p += tx;
+		p++;
+	}
+
+	*end |= 1; // allow joybus to re-parse the command buffer
+}
+
 static void librtc_pif_save() {
 	s_prev_dma_addr = *((volatile unsigned int*)0xa4800000u);
 
@@ -160,8 +189,15 @@ static void librtc_pif_save() {
 	for( int i = 0; i < 16; i++ ) {
 		s_si_backup[i] = si_pif_ram[i];
 	}
-	
-	s_si_backup[15] |= 1u;
+
+	if( s_exec_on_write_bug ) {
+		// The emulator incorrectly executes the joybus on a DMA write instead of a read
+		// Clear the command register so it doesn't execute again
+		s_si_backup[15] &= 0xffffff00u;
+	} else {
+		asm volatile( "":::"memory" );
+		librtc_sanitize_saved_pif_ram();
+	}
 }
 
 static void librtc_pif_restore() {
@@ -175,11 +211,11 @@ static void librtc_pif_restore() {
 	*((volatile unsigned int*)0xa4800010u) = 0x1fc007c0u;
 	asm volatile( "":::"memory" );
 	si_await_op();
-	
+
 	*((volatile unsigned int*)0xa4800000u) = s_prev_dma_addr;
 }
 
-static void librtc_send_cmd() {
+static void librtc_dma_write() {
 	__builtin_mips_cache( 0x19, &s_si_buffer[0] );
 	__builtin_mips_cache( 0x19, &s_si_buffer[4] );
 	__builtin_mips_cache( 0x19, &s_si_buffer[8] );
@@ -191,7 +227,9 @@ static void librtc_send_cmd() {
 	asm volatile( "":::"memory" );
 
 	si_await_op();
+}
 
+static void librtc_dma_read() {
 	*((volatile unsigned int*)0xa4800000u) = (unsigned int)s_si_buffer & 0x1FFFFFFFu;
 	asm volatile( "":::"memory" );
 	*((volatile unsigned int*)0xa4800004u) = 0x1fc007c0u;
@@ -203,6 +241,12 @@ static void librtc_send_cmd() {
 	__builtin_mips_cache( 0x11, &s_si_buffer[4] );
 	__builtin_mips_cache( 0x11, &s_si_buffer[8] );
 	__builtin_mips_cache( 0x11, &s_si_buffer[12] );
+}
+
+__attribute__((always_inline))
+static inline void librtc_exec() {
+	librtc_dma_write();
+	librtc_dma_read();
 }
 
 static inline unsigned char decode_rtc_byte( unsigned char x ) {
@@ -287,7 +331,18 @@ librtc_bool librtc_init() {
 	s_si_buffer[2] = 0xfffffffeu;
 	librtc_zero_words( &s_si_buffer[3], 12 );
 	s_si_buffer[15] = 1u;
-	librtc_send_cmd();
+	librtc_dma_write();
+
+	if(
+		*((volatile unsigned char*)0xbfc007c6u) != 0x03 ||
+		*((volatile unsigned char*)0xbfc007c8u) != 0xff
+	) {
+		// On hardware (and accurate emulators such as Ares), writing to the joybus merely causes it to parse the command.
+		// The commands are not actually executed until a DMA read is performed. So only the final byte should have changed.
+		s_exec_on_write_bug = true;
+	}
+
+	librtc_dma_read();
 
 	if( s_si_buffer[2] >> 8 != 0x001000u ) {
 		librtc_pif_restore();
@@ -304,13 +359,13 @@ librtc_bool librtc_init() {
 	s_si_buffer[4] = 0x00fe0000u;
 	librtc_zero_words( &s_si_buffer[5], 10 );
 	s_si_buffer[15] = 1u;
-	librtc_send_cmd();
+	librtc_exec();
 
 	s_si_buffer[1] = 0x0a010800u;
 	s_si_buffer[2] = 0x03000000u;
 	s_si_buffer[4] = 0x00fe0000u;
 	s_si_buffer[15] = 1u;
-	librtc_send_cmd();
+	librtc_exec();
 
 	s_wait_start = librtc_clock();
 	s_wait_end = s_wait_start + (LIBRTC_CLOCKS_PER_SEC / 50u);
@@ -370,7 +425,7 @@ librtc_bool librtc_get_time_raw( librtc_time *tm ) {
 	s_si_buffer[4] = 0x80fe0000u;
 	librtc_zero_words( &s_si_buffer[5], 10 );
 	s_si_buffer[15] = 1u;
-	librtc_send_cmd();
+	librtc_exec();
 
 	const unsigned char *const data = (const unsigned char*)&s_si_buffer[2];
 	tm->tm_sec = (int)decode_rtc_byte( data[0] );

--- a/lib/librtc/librtc.c
+++ b/lib/librtc/librtc.c
@@ -261,7 +261,7 @@ static inline void librtc_set_month_and_day( long long year, int yday, int *mon,
 	} else for( int month = (yday + 4) >> 5;; month++ ) {
 		if( yday < s_yday_table[month+1] ) {
 			*mon = month;
-			*mday = yday - s_yday_table[month];
+			*mday = yday + 1 - s_yday_table[month];
 			return;
 		}
 	}
@@ -665,7 +665,7 @@ unsigned int librtc_strftime_internal( char *str, unsigned int count, const char
 				break;
 			case 'e':
 				if( i >= count - 2 ) return 0;
-				if( alt || tp->tm_mday >= 9) {
+				if( alt || tp->tm_mday > 9) {
 					str[i++] = '0' + (char)(tp->tm_mday / 10);
 					str[i++] = '0' + (char)(tp->tm_mday % 10);
 				} else {

--- a/lib/librtc/librtc.c
+++ b/lib/librtc/librtc.c
@@ -417,7 +417,7 @@ librtc_bool librtc_from_unix_time( long long unixTime, librtc_time *tm ) {
 		tm->tm_hour = 0;
 		tm->tm_mday = 1;
 		tm->tm_mon = 0;
-		tm->tm_year = -0x8FFFFFFF;
+		tm->tm_year = -0x80000000;
 		tm->tm_wday = 4;
 		tm->tm_yday = 0;
 		return false;

--- a/lib/librtc/librtc.c
+++ b/lib/librtc/librtc.c
@@ -1,0 +1,722 @@
+/* librtc
+ * by Matt "falcobuster" Pharoah
+ * https://gitlab.com/mpharoah/librtc
+ *
+ * The proper 64 byte RTC commands needed to interface with the RTC were taken from libdragon
+ * (https://github.com/DragonMinded/libdragon)
+ *
+ * Public Domain (www.unlicense.org)
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or distribute this software, either in source code form or as a
+ * compiled binary, for any purpose, commercial or non-commercial, and by any means.
+ */
+
+#include "librtc.h"
+
+#ifdef __cplusplus
+	#define librtc_register
+#else
+	#define librtc_register register
+	#if __STDC_VERSION__ < 202311L
+		#ifndef true
+			#define true 1
+		#endif
+
+		#ifndef false
+			#define false 0
+		#endif
+	#endif
+#endif
+
+#define LIBRTC_CLOCKS_PER_SEC 46875000u
+
+#define LIBRTC_SECONDS_IN_MINUTE 60ll
+#define LIBRTC_SECONDS_IN_HOUR (60ll * LIBRTC_SECONDS_IN_MINUTE)
+#define LIBRTC_SECONDS_IN_DAY (24ll * LIBRTC_SECONDS_IN_HOUR)
+#define LIBRTC_SECONDS_IN_NON_LEAP_YEAR (365ll * LIBRTC_SECONDS_IN_DAY)
+
+static const librtc_time LIBRTC_UNIX_EPOCH = {
+	0, 0, 0, 1, 0, 70, 4, 0, -1
+};
+
+static const char *s_weekdayNames[7] = {
+	"Sunday",
+	"Monday",
+	"Tuesday",
+	"Wednesday",
+	"Thursday",
+	"Friday",
+	"Saturday"
+};
+
+static const char *s_monthNames[12] = {
+	"January",
+	"February",
+	"March",
+	"April",
+	"May",
+	"June",
+	"July",
+	"August",
+	"September",
+	"October",
+	"November",
+	"December"
+};
+
+static const int s_yday_table[12] = {
+	0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334
+};
+
+static const unsigned int SI_GET_RTC_TIME_CMD[16] = {
+	0u, 0x02090702u, 0xffffffffu, 0xffffffffu, 0xfffe0000u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u ,0u ,0u, 1u
+};
+
+static const unsigned int SI_GET_RTC_STATUS_CMD[16] = {
+	0u, 0xff010306u, 0xfffffffeu, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u ,0u ,0u, 1u
+};
+
+static const unsigned int SI_GET_RTC_CTRL_CMD[16] = {
+	0u, 0x02090700u, 0xffffffffu, 0xffffffffu, 0xfffe0000u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u ,0u ,0u, 1u
+};
+
+static const unsigned int SI_SET_RTC_CTRL_CMD_TEMPLATE[16] = {
+	0u, 0x0a010800u, 0x03000000u, 0u, 0xfffe0000u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u ,0u ,0u, 1u
+};
+
+static const unsigned int SI_REENABLE_CONTROLLERS_CMD[16] = {
+	0xff010401u, 0xffffffffu, 0xff010401u, 0xffffffffu, 0xff010401u, 0xffffffffu, 0xff010401u, 0xffffffffu, 0xfe000000u, 0u, 0u, 0u, 0u, 0u, 0u, 1u
+};
+
+static unsigned int s_si_buffer[16] __attribute__((aligned(16)));
+
+typedef enum {
+	LIBRTC_INIT_CALLED = 0x1,
+	LIBRTC_NOT_WAITING = 0x2,
+	LIBRTC_GOOD = 0x4,
+
+	LIBRTC_READY = LIBRTC_INIT_CALLED | LIBRTC_NOT_WAITING
+} librtc_state_t;
+
+static librtc_state_t s_rtc_state;
+static long long s_wait_start;
+static long long s_wait_end;
+
+static long long s_offset = 0ll;
+
+__attribute__((always_inline))
+static inline void librtc_copy( librtc_time *dest, const librtc_time *src ) {
+	dest->tm_sec = src->tm_sec;
+	dest->tm_min = src->tm_min;
+	dest->tm_hour = src->tm_hour;
+	dest->tm_mday = src->tm_mday;
+	dest->tm_mon = src->tm_mon;
+	dest->tm_year = src->tm_year;
+	dest->tm_wday = src->tm_wday;
+	dest->tm_yday = src->tm_yday;
+	dest->tm_isdst = src->tm_isdst;
+}
+
+__attribute__((always_inline))
+static inline long long librtc_clock() {
+	long long count;
+	asm volatile( "mfc0 %0, $9": "=r"( count ) );
+	return count;
+}
+
+__attribute__((noinline))
+static librtc_bool librtc_enable_interrupts() {
+	librtc_register librtc_bool status;
+	asm volatile( ".set noat \n\t .align 16 \n\t mfc0 $1, $12 \n\t andi %0, $1, 1 \n\t ori  $1, $1, 1  \n\t mtc0 $1, $12" : "=r"( status ) :: "at" );
+	return status;
+}
+
+__attribute__((noinline))
+static librtc_bool librtc_disable_interrupts() {
+	librtc_register librtc_bool status;
+	asm volatile( ".set noat \n\t .align 16 \n\t mfc0 $1, $12 \n\t andi %0, $1, 1 \n\t subu $1, $1, %0 \n\t mtc0 $1, $12" : "=r"( status ) :: "at" );
+	return status;
+}
+
+__attribute__((always_inline))
+static inline librtc_bool librtc_set_interrupts( librtc_bool enable ) {
+	return enable ? librtc_enable_interrupts() : librtc_disable_interrupts();
+}
+
+static inline void __attribute__((always_inline)) si_await_op() {
+	// Wait for the SI operation we started to finish, then clear the status
+	while( !(*((volatile unsigned int*)0xa4300008u) & *((volatile unsigned int*)0xa430000Cu) & 0x2u) );
+	*((volatile unsigned int*)0xa4800018u) = 0u;
+}
+
+static inline void __attribute__((always_inline)) si_wait_safe( librtc_bool yield ) {
+	// If the SI is currently busy, wait until it isn't
+	while( *((volatile unsigned int*)0xa4800018u) & 0x3 ) {
+		librtc_set_interrupts( yield );
+		while( *((volatile unsigned int*)0xa4800018u) & 0x3 );
+		librtc_set_interrupts( false );
+	}
+}
+
+static void librtc_exec( const unsigned int *cmd ) {
+	for( int i = 0; i < 16; i++ ) {
+		s_si_buffer[i] = cmd[i];
+	}
+
+	__builtin_mips_cache( 0x19, &s_si_buffer[0] );
+	__builtin_mips_cache( 0x19, &s_si_buffer[4] );
+	__builtin_mips_cache( 0x19, &s_si_buffer[8] );
+	__builtin_mips_cache( 0x19, &s_si_buffer[12] );
+
+	*((volatile unsigned int*)0xa4800000u) = (unsigned int)s_si_buffer;
+	asm volatile( "":::"memory" );
+	*((volatile unsigned int*)0xa4800010u) = 0x1fc007c0u;
+	asm volatile( "":::"memory" );
+
+	si_await_op();
+
+	__builtin_mips_cache( 0x11, &s_si_buffer[0] );
+	__builtin_mips_cache( 0x11, &s_si_buffer[4] );
+	__builtin_mips_cache( 0x11, &s_si_buffer[8] );
+	__builtin_mips_cache( 0x11, &s_si_buffer[12] );
+
+	*((volatile unsigned int*)0xa4800000u) = (unsigned int)s_si_buffer;
+	asm volatile( "":::"memory" );
+	*((volatile unsigned int*)0xa4800004u) = 0x1fc007c0u;
+	asm volatile( "":::"memory" );
+
+	si_await_op();
+}
+
+static inline unsigned char decode_rtc_byte( unsigned char x ) {
+	return (((x & 0xF0) >> 4) * 10) + (x & 0x0F);
+}
+
+static inline librtc_bool is_leap_year( long long year ) {
+	if( year % 4ll != 0ll ) return false;
+	if( year % 100ll == 0ll ) return (year % 400ll == 0ll) ? true : false;
+	return false;
+}
+
+static long long year_to_unix_time( long long year ) {
+	librtc_register long long leapYears = -478ll;
+	leapYears += (year + 3ll) >> 2;
+	leapYears -= ((year > 0ll) ? (year + 99ll) : year) / 100ll;
+	leapYears += ((year > 0ll) ? (year + 399ll) : year) / 400ll;
+
+	return (
+		((year - 1970ll) * LIBRTC_SECONDS_IN_NON_LEAP_YEAR) +
+		(leapYears * LIBRTC_SECONDS_IN_DAY)
+	);
+}
+
+__attribute__((always_inline))
+static inline librtc_bool librtc_is_emulator() {
+	librtc_register const volatile unsigned int *const dpc = (const volatile unsigned int*)0xA4100000u;
+	return !(dpc[5] | dpc[6] | dpc[7]);
+}
+
+__attribute__((always_inline))
+static inline void librtc_set_month_and_day( long long year, int yday, int *mon, int *mday ) {
+	if( yday < 31 ) {
+		*mon = 0;
+		*mday = yday + 1;
+		return;
+	} else if( yday < 59 ) {
+		*mon = 1;
+		*mday = yday - 30;
+		return;
+	} else if( yday == 59 ) {
+		if( is_leap_year( year ) ) {
+			*mon = 1;
+			*mday = 29;
+		} else {
+			*mon = 2;
+			*mday = 1;
+		}
+		return;
+	}
+
+	if( is_leap_year( year ) ) yday--;
+	if( yday >= 334 ) {
+		*mon = 11;
+		*mday = yday - 333;
+	} else for( int month = (yday + 4) >> 5;; month++ ) {
+		if( yday < s_yday_table[month+1] ) {
+			*mon = month;
+			*mday = yday - s_yday_table[month];
+			return;
+		}
+	}
+}
+
+librtc_bool librtc_init() {
+	if( s_rtc_state & LIBRTC_INIT_CALLED ) {
+		return s_rtc_state != LIBRTC_READY;
+	}
+
+	const librtc_bool intr = librtc_set_interrupts( false );
+	if( s_rtc_state & LIBRTC_INIT_CALLED ) {
+		librtc_set_interrupts( intr );
+		return s_rtc_state != LIBRTC_READY;
+	}
+
+	const librtc_bool isEmulator = librtc_is_emulator();
+	if( isEmulator ) {
+		// Check for Project 64 specifically. This emulator has a major bug that causes all controller inputs to stop working if
+		// attempting to initialize the RTC after the controllers, so we should avoid attempting to interface with the RTC at all
+		// on Project 64. (Project 64 doesn't support RTC anyway) This bug is present on all versions of PJ64 so far.
+		// No other emulator has this bug, and it is safe on console. It's just yet another PJ64 bug.
+
+		// This is one of the few PJ64 checks that doesn't result in PJ64 halting, crashing, or breaking input
+		if(
+			*((const volatile unsigned int*)0xbfd00104) == 0x01040104u && // expected behaviour
+			*((const volatile unsigned short*)0xbfd00106) == 0u // PJ64 specific behaviour
+		) {
+			s_rtc_state = LIBRTC_READY;
+			librtc_set_interrupts( intr );
+			return false;
+		}
+	}
+
+	si_wait_safe( intr );
+	s_rtc_state |= LIBRTC_INIT_CALLED;
+
+	librtc_exec( SI_GET_RTC_STATUS_CMD );
+	if( s_si_buffer[3] || (s_si_buffer[2] >> 8) != 0x1000u ) {
+		librtc_exec( SI_REENABLE_CONTROLLERS_CMD );
+		librtc_set_interrupts( intr );
+		return false;
+	}
+
+	s_rtc_state |= LIBRTC_GOOD;
+	librtc_exec( SI_GET_RTC_CTRL_CMD );
+
+	unsigned int cmd[16];
+	for( int i = 0; i < 16; i++ ) {
+		cmd[i] = SI_SET_RTC_CTRL_CMD_TEMPLATE[i];
+	}
+	cmd[3] = s_si_buffer[3];
+
+	librtc_exec( cmd );
+
+	s_wait_start = librtc_clock();
+	s_wait_end = s_wait_start + (LIBRTC_CLOCKS_PER_SEC / 50u);
+
+	if( isEmulator ) {
+		s_rtc_state |= LIBRTC_NOT_WAITING;
+	}
+
+	librtc_exec( SI_REENABLE_CONTROLLERS_CMD );
+	librtc_set_interrupts( intr );
+	return true;
+}
+
+librtc_bool librtc_ready() {
+	if( !(s_rtc_state & LIBRTC_INIT_CALLED) ) return false;
+	if( !(s_rtc_state & LIBRTC_NOT_WAITING) ) {
+		const long long now = librtc_clock();
+		if( s_wait_end < s_wait_start ) {
+			if( now >= s_wait_end && now < s_wait_start ) {
+				s_rtc_state |= LIBRTC_NOT_WAITING;
+				return true;
+			} else {
+				return false;
+			}
+		} else {
+			if( now < s_wait_start || now >= s_wait_end ) {
+				s_rtc_state |= LIBRTC_NOT_WAITING;
+				return true;
+			} else {
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
+librtc_bool librtc_get_time_raw( librtc_time *tm ) {
+	if( !(s_rtc_state & LIBRTC_READY) ) {
+		librtc_init();
+		while( !librtc_ready() );
+	}
+
+	if( !(s_rtc_state & LIBRTC_GOOD) ) {
+		librtc_copy( tm, &LIBRTC_UNIX_EPOCH );
+		return false;
+	}
+
+	const librtc_bool intr = librtc_set_interrupts( false );
+	si_wait_safe( intr );
+
+	librtc_exec( SI_GET_RTC_TIME_CMD );
+	const unsigned char *const data = (const unsigned char*)&s_si_buffer[2];
+	tm->tm_sec = (int)decode_rtc_byte( data[0] );
+	tm->tm_min = (int)decode_rtc_byte( data[1] );
+	tm->tm_hour = (int)decode_rtc_byte( data[2] - 0x80 );
+	tm->tm_mday = (int)decode_rtc_byte( data[3] );
+	tm->tm_wday = (int)decode_rtc_byte( data[4] );
+	tm->tm_mon = (int)decode_rtc_byte( data[5] ) - 1u;
+	tm->tm_year = (100 * (int)decode_rtc_byte( data[7] )) + (int)decode_rtc_byte( data[6] );
+	if( tm->tm_mon < 12 ) tm->tm_yday = s_yday_table[tm->tm_mon] + tm->tm_mday - 1;
+	tm->tm_isdst = -1;
+
+	if( tm->tm_mon >= 2 && is_leap_year( 1900ll + (long long)tm->tm_year ) ) {
+		tm->tm_yday++;
+	}
+
+	librtc_exec( SI_REENABLE_CONTROLLERS_CMD );
+	librtc_set_interrupts( intr );
+	return true;
+}
+
+void librtc_set_offset( long long offset ) {
+	s_offset = offset;
+}
+
+long long librtc_set_time( const librtc_time *now ) {
+	librtc_time epoch;
+	if( librtc_get_time_raw( &epoch ) ) {
+		s_offset = librtc_time_diff( &epoch, now );
+	}
+
+	return s_offset;
+}
+
+librtc_bool librtc_get_time( librtc_time *tm ) {
+	if( !librtc_get_time_raw( tm ) ) {
+		return false;
+	}
+
+	if( s_offset ) {
+		librtc_add_time( tm, s_offset );
+	}
+
+	return true;
+}
+
+long long librtc_to_unix_time( const librtc_time *tm ) {
+	int month = tm->tm_mon % 12;
+	if( month < 0 ) month += 12;
+
+	long long days = (long long)s_yday_table[month] + (long long)tm->tm_mday - 1ll;
+	if( month >= 2 && is_leap_year( (long long)tm->tm_year + 1900ll ) ) days++;
+	return (
+		year_to_unix_time( (long long)tm->tm_year + 1900ll + (long long)(tm->tm_mon / 12) ) +
+		(days * LIBRTC_SECONDS_IN_DAY) +
+		((long long)tm->tm_hour * LIBRTC_SECONDS_IN_HOUR) +
+		((long long)tm->tm_min * LIBRTC_SECONDS_IN_MINUTE) +
+		(long long)tm->tm_sec
+	);
+}
+
+librtc_bool librtc_from_unix_time( long long unixTime, librtc_time *tm ) {
+	tm->tm_isdst = 0;
+
+	if( unixTime >= 67768036191676800ll ) {
+		// set to maximum valid time
+		tm->tm_sec = 59;
+		tm->tm_min = 59;
+		tm->tm_hour = 23;
+		tm->tm_mday = 31;
+		tm->tm_mon = 11;
+		tm->tm_year = 0x7FFFFFFF;
+		tm->tm_wday = 3;
+		tm->tm_yday = 364;
+		return false;
+	} else if( unixTime < -67768040609721748ll ) {
+		// set to minimum valid time
+		tm->tm_sec = 0;
+		tm->tm_min = 0;
+		tm->tm_hour = 0;
+		tm->tm_mday = 1;
+		tm->tm_mon = 0;
+		tm->tm_year = -0x8FFFFFFF;
+		tm->tm_wday = 4;
+		tm->tm_yday = 0;
+		return false;
+	}
+
+	long long yearGuess = 1970ll + (unixTime / 31556952ll);
+	long long yearTs = year_to_unix_time( yearGuess );
+	if( unixTime < yearTs ) {
+		do {
+			yearTs = year_to_unix_time( --yearGuess );
+		} while( unixTime < yearTs );
+	} else if( yearGuess > 0x7fffffffll ) {
+		yearGuess = 0x7fffffffll;
+		yearTs = year_to_unix_time( yearGuess );
+	} else {
+		librtc_register const long long nextYearTs = year_to_unix_time( yearGuess + 1ll );
+		if( unixTime >= nextYearTs ) {
+			yearGuess++;
+			yearTs = nextYearTs;
+		}
+	}
+
+	int ts = (int)(unixTime - yearTs);
+	tm->tm_year = (int)(yearGuess - 1900ll);
+	tm->tm_yday = ts / (int)LIBRTC_SECONDS_IN_DAY;
+	ts %= (int)LIBRTC_SECONDS_IN_DAY;
+	librtc_set_month_and_day( yearGuess, tm->tm_yday, &tm->tm_mon, &tm->tm_mday );
+	tm->tm_hour = ts / (int)LIBRTC_SECONDS_IN_HOUR;
+	ts %= (int)LIBRTC_SECONDS_IN_HOUR;
+	tm->tm_min = ts / (int)LIBRTC_SECONDS_IN_MINUTE;
+	tm->tm_sec = ts % (int)LIBRTC_SECONDS_IN_MINUTE;
+	tm->tm_wday = (int)((4ll + (unixTime / LIBRTC_SECONDS_IN_DAY)) % 7ll);
+	if( tm->tm_wday < 0 ) tm->tm_wday += 7;
+
+	return true;
+}
+
+static inline librtc_bool strftime_push_text( char *str, unsigned int *i, unsigned int count, const char *text ) {
+	for( ; *text; (*i)++ ) {
+		if( *i >= count - 1 ) return false;
+		str[*i] = *(text++);
+	}
+	return true;
+}
+
+static inline librtc_bool strftime_push_number( char *str, unsigned int *i, unsigned int count, long long n ) {
+	if( n < 0ll ) {
+		str[(*i)++] = '-';
+		n = -n;
+	}
+
+	char buff[17];
+	unsigned int j = 0u;
+	do {
+		buff[j++] = '0' + (char)(n % 10ll);
+		n /= 10ll;
+	} while( n );
+
+	if( *i + j < *i || *i + j >= count ) return false;
+	for( int k = (int)j - 1; k >= 0; k-- ) {
+		str[(*i)++] = buff[k];
+	}
+
+	return true;
+}
+
+static inline int get_wby_days( int day, int wday ) {
+	return day - ((day - wday + 382) % 7) + 3;
+}
+
+static long long get_wby_years( long long year, int day, int wday ) {
+	if( get_wby_days( day, wday ) < 0 ) {
+		return year - 1ll;
+	} else if( get_wby_days( day - (is_leap_year( year ) ? 366ll : 365ll), wday ) > 0 ) {
+		return year + 1ll;
+	} else {
+		return year;
+	}
+}
+
+static int get_wby_weeks( long long year, int day, int wday ) {
+	int days = get_wby_days( day, wday );
+	if( days < 0 ) {
+		days = get_wby_days( day + (is_leap_year( year ) ? 366ll : 365ll), wday );
+	} else {
+		const int days2 = get_wby_days( day - (is_leap_year( year ) ? 366ll : 365ll), wday );
+		if( days2 > 0 ) days = days2;
+	}
+
+	return 1 + (days / 7);
+}
+
+unsigned int librtc_strftime_internal( char *str, unsigned int count, const char *format, const librtc_time *tp ) {
+	const long long year = (long long)tp->tm_year + 1900ll;
+	for( unsigned int i = 0; i < count; format++ ) {
+		if( !*format ) {
+			str[i] = '\0';
+			return i;
+		} else if( *format != '%' ) {
+			str[i++] = *format;
+			continue;
+		}
+
+		format++;
+		const librtc_bool alt = (*format == '0');
+		if( *format == 'E' || alt ) {
+			format++;
+		}
+
+		switch( *format ) {
+			case '%':
+				str[i++] = '%';
+				break;
+			case 'n':
+				str[i++] = '\n';
+				break;
+			case 't':
+				str[i++] = '\t';
+				break;
+			case 'Y':
+				if( !strftime_push_number( str, &i, count, year ) ) return 0;
+				break;
+			case 'y':
+				if( i < count - 2 ) {
+					librtc_register int yy = (int)(year % 100ll);
+					if( yy < 0 ) yy += 100;
+					str[i++] = '0' + (char)(yy / 10);
+					str[i++] = '0' + (char)(yy % 10);
+					break;
+				} else return 0;
+			case 'C':
+				if( !strftime_push_number( str, &i, count, year / 100ll ) ) return 0;
+				break;
+			case 'G':
+				if( !strftime_push_number( str, &i, count, get_wby_years(year, tp->tm_yday, tp->tm_wday ) ) ) return 0;
+				break;
+			case 'g':
+				if( i < count - 2 ) {
+					librtc_register int wyear = (int)(get_wby_years(year, tp->tm_yday, tp->tm_wday ) % 100ll);
+					if( wyear < 0 ) wyear += 100;
+					str[i++] = '0' + (char)(wyear / 10);
+					str[i++] = '0' + (char)(wyear % 10);
+					break;
+				} else return 0;
+				break;
+			case 'b':
+			case 'h':
+				if( i >= count - 3 ) return 0;
+				str[i++] = s_monthNames[tp->tm_mon][0];
+				str[i++] = s_monthNames[tp->tm_mon][1];
+				str[i++] = s_monthNames[tp->tm_mon][2];
+				break;
+			case 'B':
+				if( !strftime_push_text( str, &i, count, s_monthNames[tp->tm_mon] ) ) return 0;
+				break;
+			case 'm':
+				if( i >= count - 2 ) return 0;
+				str[i++] = '0' + (char)((tp->tm_mon + 1) / 10);
+				str[i++] = '0' + (char)((tp->tm_mon + 1) % 10);
+				break;
+			case 'U':
+				if( i >= count - 2 ) return 0;
+				str[i++] = '0' + (char)((tp->tm_yday - tp->tm_wday + 7) / 70);
+				str[i++] = '0' + (char)(((tp->tm_yday - tp->tm_wday + 7) / 7) % 10);
+				break;
+			case 'W':
+				if( i >= count - 2 ) return 0;
+				str[i++] = '0' + (char)((tp->tm_yday - ((tp->tm_wday + 6) % 7) + 7) / 70);
+				str[i++] = '0' + (char)(((tp->tm_yday - ((tp->tm_wday + 6) % 7) + 7) / 7) % 10);
+				break;
+			case 'V':
+				if( i < count - 2 ) {
+					librtc_register const int week = get_wby_weeks(year, tp->tm_yday, tp->tm_wday );
+					str[i++] = '0' + (char)(week / 10);
+					str[i++] = '0' + (char)(week % 10);
+					break;
+				} else return 0;
+			case 'j':
+				if( i >= count - 3 ) return 0;
+				str[i++] = '0' + (char)(tp->tm_yday / 100);
+				str[i++] = '0' + (char)((tp->tm_yday / 10) % 10);
+				str[i++] = '0' + (char)(tp->tm_yday % 10);
+				break;
+			case 'd':
+				if( i >= count - 2 ) return 0;
+				str[i++] = '0' + (char)(tp->tm_mday / 10);
+				str[i++] = '0' + (char)(tp->tm_mday % 10);
+				break;
+			case 'e':
+				if( i >= count - 2 ) return 0;
+				if( alt || tp->tm_mday >= 9) {
+					str[i++] = '0' + (char)(tp->tm_mday / 10);
+					str[i++] = '0' + (char)(tp->tm_mday % 10);
+				} else {
+					str[i++] = ' ';
+					str[i++] = '0' + (char)tp->tm_mday;
+				}
+				break;
+			case 'a':
+				if( i >= count - 3 ) return 0;
+				str[i++] = s_weekdayNames[tp->tm_wday][0];
+				str[i++] = s_weekdayNames[tp->tm_wday][1];
+				str[i++] = s_weekdayNames[tp->tm_wday][2];
+				break;
+			case 'A':
+				if( !strftime_push_text( str, &i, count, s_weekdayNames[tp->tm_wday] ) ) return 0;
+				break;
+			case 'w':
+				str[i++] = '0' + (char)tp->tm_wday;
+				break;
+			case 'u':
+				str[i++] = tp->tm_wday ? ('0' + (char)tp->tm_wday) : '7';
+				break;
+			case 'H':
+				if( i >= count - 2 ) return 0;
+				str[i++] = '0' + (char)(tp->tm_hour / 10);
+				str[i++] = '0' + (char)(tp->tm_hour % 10);
+				break;
+			case 'I':
+				if( i >= count - 2 ) return 0;
+				str[i++] = '0' + (char)((1 + ((tp->tm_hour + 11) % 12)) / 10);
+				str[i++] = '0' + (char)((1 + ((tp->tm_hour + 11) % 12)) % 10);
+				break;
+			case 'M':
+				if( i >= count - 2 ) return 0;
+				str[i++] = '0' + (char)(tp->tm_min / 10);
+				str[i++] = '0' + (char)(tp->tm_min % 10);
+				break;
+			case 'S':
+				if( i >= count - 2 ) return 0;
+				str[i++] = '0' + (char)(tp->tm_sec / 10);
+				str[i++] = '0' + (char)(tp->tm_sec % 10);
+				break;
+			case 'p':
+				if( i >= count - 2 ) return 0;
+				str[i++] = (tp->tm_hour < 12) ? 'A' : 'P';
+				str[i++] = 'M';
+				break;
+			case 'c':
+				if( i < count - 21 ) {
+					const unsigned int j = librtc_strftime_internal( &str[i], count - (unsigned int)i, "%a %b %e %H:%M:%S %Y", tp );
+					if( !j ) return 0;
+					i += j;
+					break;
+				} else return 0;
+			case 'x':
+			case 'D':
+				if( i >= count - 8 ) return 0;
+				i += librtc_strftime_internal( &str[i], count - (unsigned int)i, "%m/%d/%y", tp );
+				break;
+			case 'X':
+			case 'T':
+				if( i >= count - 8 ) return 0;
+				i += librtc_strftime_internal( &str[i], count - (unsigned int)i, "%H:%M:%S", tp );
+				break;
+			case 'F':
+				if( i < count - 7 ) {
+					const unsigned int j = librtc_strftime_internal( &str[i], count - (unsigned int)i, "%Y-%m-%d", tp );
+					if( !j ) return 0;
+					i += j;
+					break;
+				} else return 0;
+			case 'r':
+				if( i >= count - 11 ) return 0;
+				i += librtc_strftime_internal( &str[i], count - (unsigned int)i, "%I:%M:%S %p", tp );
+				break;
+			case 'R':
+				if( i >= count - 5 ) return 0;
+				i += librtc_strftime_internal( &str[i], count - (unsigned int)i, "%H:%M", tp );
+				break;
+			default:
+				return 0;
+		}
+	}
+
+	return 0;
+}
+
+unsigned int librtc_strftime( char *str, unsigned int count, const char *format, const librtc_time *tp ) {
+	librtc_time tm;
+	librtc_copy( &tm, tp );
+	librtc_normalize( &tm );
+
+	str[count - 1] = '\0';
+	return librtc_strftime_internal( str, count, format, &tm );
+}

--- a/lib/librtc/librtc.c
+++ b/lib/librtc/librtc.c
@@ -71,10 +71,9 @@ static const int s_yday_table[12] = {
 	0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334
 };
 
-#define LIBRTC_GET_TIME_CMD 0x020907u
-#define LIBRTC_GET_STATUS_CMD 0x010306u
-
 static unsigned int s_si_buffer[16] __attribute__((aligned(16)));
+static volatile unsigned int s_si_backup[16] __attribute__((aligned(16)));
+static unsigned int s_prev_dma_addr;
 
 typedef enum {
 	LIBRTC_INIT_CALLED = 0x1,
@@ -90,6 +89,11 @@ static long long s_wait_end;
 
 static long long s_offset = 0ll;
 static int s_tod_offset = 0;
+
+__attribute__((always_inline))
+static inline void librtc_zero_words( unsigned int *addr, unsigned int numWords ) {
+	for( unsigned int i = 0; i < numWords; i++ ) addr[i] = 0u;
+}
 
 __attribute__((always_inline))
 static inline void librtc_copy( librtc_time *dest, const librtc_time *src ) {
@@ -145,6 +149,36 @@ static inline void __attribute__((always_inline)) si_wait_safe( librtc_bool yiel
 	}
 }
 
+static void librtc_pif_save() {
+	s_prev_dma_addr = *((volatile unsigned int*)0xa4800000u);
+
+	// Save the state of PIF RAM to memory to restore it later.
+	// The joybus is only executed when using an SI DMA read, and not when doing
+	// a direct read via the memory-mapped address. Thus, this has no side effects.
+
+	volatile unsigned int *si_pif_ram = (volatile unsigned int *)0xbfc007c0u;
+	for( int i = 0; i < 16; i++ ) {
+		s_si_backup[i] = si_pif_ram[i];
+	}
+	
+	s_si_backup[15] |= 1u;
+}
+
+static void librtc_pif_restore() {
+	__builtin_mips_cache( 0x19, &s_si_backup[0] );
+	__builtin_mips_cache( 0x19, &s_si_backup[4] );
+	__builtin_mips_cache( 0x19, &s_si_backup[8] );
+	__builtin_mips_cache( 0x19, &s_si_backup[12] );
+
+	*((volatile unsigned int*)0xa4800000u) = (unsigned int)s_si_backup & 0x1FFFFFFFu;
+	asm volatile( "":::"memory" );
+	*((volatile unsigned int*)0xa4800010u) = 0x1fc007c0u;
+	asm volatile( "":::"memory" );
+	si_await_op();
+	
+	*((volatile unsigned int*)0xa4800000u) = s_prev_dma_addr;
+}
+
 static void librtc_send_cmd() {
 	__builtin_mips_cache( 0x19, &s_si_buffer[0] );
 	__builtin_mips_cache( 0x19, &s_si_buffer[4] );
@@ -163,40 +197,12 @@ static void librtc_send_cmd() {
 	*((volatile unsigned int*)0xa4800004u) = 0x1fc007c0u;
 	asm volatile( "":::"memory" );
 
+	si_await_op();
+
 	__builtin_mips_cache( 0x11, &s_si_buffer[0] );
 	__builtin_mips_cache( 0x11, &s_si_buffer[4] );
 	__builtin_mips_cache( 0x11, &s_si_buffer[8] );
 	__builtin_mips_cache( 0x11, &s_si_buffer[12] );
-
-	si_await_op();
-}
-
-static void librtc_exec( unsigned int cmd, unsigned char arg, unsigned int unk ) {
-	s_si_buffer[0] = 0u;
-	s_si_buffer[1] = (cmd << 8) | (unsigned int)arg;
-	s_si_buffer[2] = 0xFFFFFFFFu;
-	s_si_buffer[3] = 0xFFFFFFFFu;
-	s_si_buffer[4] = unk;
-	for( int i = 5; i < 15; i++ ) {
-		s_si_buffer[i] = 0u;
-	}
-	s_si_buffer[15] = 1u;
-
-	librtc_send_cmd();
-}
-
-static void librtc_done() {
-	for( int i = 0; i < 8; ) {
-		s_si_buffer[i++] = 0xff010401u;
-		s_si_buffer[i++] = 0xffffffffu;
-	}
-	s_si_buffer[8] = 0xfe000000u;
-	for( int i = 9; i < 15; i++ ) {
-		s_si_buffer[i] = 0u;
-	}
-	s_si_buffer[15] = 1u;
-
-	librtc_send_cmd();
 }
 
 static inline unsigned char decode_rtc_byte( unsigned char x ) {
@@ -274,15 +280,38 @@ librtc_bool librtc_init() {
 
 	si_wait_safe( intr );
 	s_rtc_state |= LIBRTC_INIT_CALLED;
+	librtc_pif_save();
 
-	librtc_exec( LIBRTC_GET_STATUS_CMD, 0, 0u );
-	if( (s_si_buffer[1] & 0xFFu) || (s_si_buffer[2] >> 16) != 0x1000u ) {
-		librtc_done();
+	s_si_buffer[0] = 0u;
+	s_si_buffer[1] = 0xff010306u;
+	s_si_buffer[2] = 0xfffffffeu;
+	librtc_zero_words( &s_si_buffer[3], 12 );
+	s_si_buffer[15] = 1u;
+	librtc_send_cmd();
+
+	if( s_si_buffer[2] >> 8 != 0x001000u ) {
+		librtc_pif_restore();
 		librtc_set_interrupts( intr );
 		return false;
 	}
 
 	s_rtc_state |= LIBRTC_GOOD;
+
+	s_si_buffer[0] = 0u;
+	s_si_buffer[1] = 0x02090700u;
+	s_si_buffer[2] = 0u;
+	s_si_buffer[3] = 0u;
+	s_si_buffer[4] = 0x00fe0000u;
+	librtc_zero_words( &s_si_buffer[5], 10 );
+	s_si_buffer[15] = 1u;
+	librtc_send_cmd();
+
+	s_si_buffer[1] = 0x0a010800u;
+	s_si_buffer[2] = 0x03000000u;
+	s_si_buffer[4] = 0x00fe0000u;
+	s_si_buffer[15] = 1u;
+	librtc_send_cmd();
+
 	s_wait_start = librtc_clock();
 	s_wait_end = s_wait_start + (LIBRTC_CLOCKS_PER_SEC / 50u);
 
@@ -290,7 +319,7 @@ librtc_bool librtc_init() {
 		s_rtc_state |= LIBRTC_NOT_WAITING;
 	}
 
-	librtc_done();
+	librtc_pif_restore();
 	librtc_set_interrupts( intr );
 	return true;
 }
@@ -332,8 +361,17 @@ librtc_bool librtc_get_time_raw( librtc_time *tm ) {
 
 	const librtc_bool intr = librtc_set_interrupts( false );
 	si_wait_safe( intr );
+	librtc_pif_save();
 
-	librtc_exec( LIBRTC_GET_TIME_CMD, 2, 0x80fe0000u );
+	s_si_buffer[0] = 0u;
+	s_si_buffer[1] = 0x02090702u;
+	s_si_buffer[2] = 0x00008001u;
+	s_si_buffer[3] = 0x04017000u;
+	s_si_buffer[4] = 0x80fe0000u;
+	librtc_zero_words( &s_si_buffer[5], 10 );
+	s_si_buffer[15] = 1u;
+	librtc_send_cmd();
+
 	const unsigned char *const data = (const unsigned char*)&s_si_buffer[2];
 	tm->tm_sec = (int)decode_rtc_byte( data[0] );
 	tm->tm_min = (int)decode_rtc_byte( data[1] );
@@ -349,7 +387,7 @@ librtc_bool librtc_get_time_raw( librtc_time *tm ) {
 		tm->tm_yday++;
 	}
 
-	librtc_done();
+	librtc_pif_restore();
 	librtc_set_interrupts( intr );
 	return true;
 }

--- a/lib/librtc/librtc.c
+++ b/lib/librtc/librtc.c
@@ -277,6 +277,7 @@ librtc_bool librtc_init() {
 
 	librtc_exec( LIBRTC_GET_STATUS_CMD, 0, 0u );
 	if( (s_si_buffer[1] & 0xFFu) || (s_si_buffer[2] >> 16) != 0x1000u ) {
+		librtc_done();
 		librtc_set_interrupts( intr );
 		return false;
 	}

--- a/lib/librtc/librtc.h
+++ b/lib/librtc/librtc.h
@@ -1,0 +1,158 @@
+/* librtc
+ * by Matt "falcobuster" Pharoah
+ * https://gitlab.com/mpharoah/librtc
+ * 
+ * The proper 64 byte RTC commands needed to interface with the RTC were taken from libdragon
+ * (https://github.com/DragonMinded/libdragon)
+ * 
+ * Public Domain (www.unlicense.org)
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or distribute this software, either in source code form or as a
+ * compiled binary, for any purpose, commercial or non-commercial, and by any means.
+ */
+
+#ifndef LIBRTC_H
+#define LIBRTC_H
+
+// <HackerSM64>
+#ifndef USE_RTC
+#error "librtc.h was included without enabling the RTC. Please set USE_RTC to 1 in the Makefile."
+#endif
+// </HackerSM64>
+
+#ifdef __cplusplus
+	typedef bool librtc_bool;
+#else
+	#if __STDC_VERSION__ >= 202311L
+		typedef bool librtc_bool;
+	#elif __STDC_VERSION__ >= 199901L
+		typedef _Bool librtc_bool;
+	#elif __GNUC__ >= 15
+		typedef unsigned char __attribute__((hardbool(0, 1))) librtc_bool;
+	#else
+		typedef unsigned char librtc_bool;
+	#endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* A structure storing the calendar time
+ * Uses the same format as the tm struct in the C standard library
+ */
+typedef struct {
+	int tm_sec; // seconds after the minute [0-59]
+	int tm_min; // minutes after the hour [0-59]
+	int tm_hour; // hours since midnight [0-23]
+	int tm_mday; // day of the month [1-31] (remember this starts from 1, not 0)
+	int tm_mon; // months since January [0-11]
+	int tm_year; // years since 1900 (remember the epoch is 1900 AD, not 1 BC)
+	int tm_wday; // days since Sunday [0-6]
+	int tm_yday; // days since January 1 [0-365]
+	int tm_isdst; // Field included for the sake of matching the C standard library. Has no effect.
+} librtc_time;
+
+
+/* Initializes the RTC clock if it has not already been initialized.
+ * Returns true if the flashcart or emulator supports a realtime clock.
+ * Note that some emulators and flashcarts may require the RTC bit to be enabled in the Everdrive ROM header.
+ * 
+ * It is not strictly necessary to call librtc_init as it will be automatically initialized when first calling
+ * librtc_get_time or librtc_get_time_raw if not yet initialized. However, to workaround bugs with some flashcarts,
+ * there will be a stutter on console the first time librtc_get_time or librtc_get_time_raw is called if librtc_init
+ * was not already called 20 milliseconds ago or more. See librtc_ready for more information.
+ */
+librtc_bool librtc_init();
+
+/* Returns false if the RTC has not been initialized or if the rom is being played on console and 20 milliseconds have not yet
+ * passed since the RTC was initialized. Otherwise, returns true, even if RTC is not supported by the flashcart or emulator.
+ *
+ * On console, there is a 20 millisecond delay between initializing the RTC and when the time can first be fetched.
+ * This delay exists to wokraround some buggy flashcarts that do not properly set the RTC status. To ensure that the RTC has had
+ * enough time to initialize on these buggy flashcarts, a 20 millisecond delay is enforced to avoid returning garbage data.
+ *
+ * NOTE: The COUNT register on the CPU is used to determine the time passed. Since this counter overflows every ~90 seconds,
+ * if the very first call to librtc_get_time or librtc_get_time occurs precisely within a 20 millisecond window after one of the
+ * ~90 second cycles since initializing the RTC, it will incorrectly believe that 20 milliseconds have not yet passed.
+ * To avoid this, you can call librtc_ready at a regular interval (less then 90 seconds), and the 20 millisecond delay will be
+ * permanently marked as complete once it has passed, ensuring that COUNT overflow will no longer be a concern.
+ */
+librtc_bool librtc_ready();
+
+/* Gets the unmodified current calendar time from the RTC.
+ * This function ignores any offset set with librtc_set_offset or librtc_set_time.
+ * Use librtc_get_time instead to get the adjusted time that respects the offset value.
+ */
+__attribute__((access(write_only, 1), nonnull(1)))
+librtc_bool librtc_get_time_raw( librtc_time *tm );
+
+/* Sets the number of seconds to be added to the raw RTC time when calling librtc_get_time */
+void librtc_set_offset( long long offset );
+
+/* Set the current time by updating the offset value such that calling librtc_get_time now would return the passed in time.
+ * Returns the new offset value in seconds.
+ */
+__attribute__((nonnull(1)))
+long long librtc_set_time( const librtc_time *now );
+
+/* Gets the current time. The offset set using librtc_set_offset or librtc_set_time is added to the raw time from the RTC.
+ * If the flashcart or emulator does not support RTC, return false and sets tm to the Unix epoch (Jan 1, 1970)
+ */
+__attribute__((access(write_only, 1), nonnull(1)))
+librtc_bool librtc_get_time( librtc_time *tm );
+
+/* Converts the passed in calendar time to Unix time, interpreting the time as UTC. */
+__attribute__((pure, nonnull(1), warn_unused_result))
+long long librtc_to_unix_time( const librtc_time *tm );
+
+/* Converts the passed in Unix time to calendar time and stores it in tm.
+ * If the passed in Unix time is too large or too small to fit in a normalized librtc_time struct,
+ * the time is clamped to the minimum/maximum value, and the function returns false.
+ */
+__attribute__((nonnull(2), access(write_only, 2)))
+librtc_bool librtc_from_unix_time( long long unixTime, librtc_time *tm );
+
+/* Adds a number of seconds to the calendar time and normalizes it.
+ * The passed in struct is modified, and a pointer to the same struct is returned.
+ */
+__attribute__((always_inline, nonnull(1), access(read_write, 1), returns_nonnull))
+inline librtc_time *librtc_add_time( librtc_time *tm, long long seconds ) {
+	seconds += librtc_to_unix_time( tm );
+	librtc_from_unix_time( seconds, tm );
+	return tm;
+}
+
+/* Returns the difference in seconds between two calendar times.
+ * If the first argument is later than the second argument, the return value is negative.
+ */
+__attribute__((pure, always_inline, warn_unused_result, nonnull(1, 2)))
+inline long long librtc_time_diff( const librtc_time *tm_a, const librtc_time *tm_b ) {
+	return librtc_to_unix_time( tm_b ) - librtc_to_unix_time( tm_a );
+}
+
+/* Normalizes the calendar time object so that all fields are in range.
+ * The day is normalized using tm_year, tm_month, and tm_day
+ * (tm_wday and tm_yday are only updated and not read).
+ * If the normalized calendar time results in a year that would overflow,
+ * the time is clamped to the minimum/maximum value, and the function returns false.
+ */
+__attribute__((always_inline, nonnull(1), access(read_write, 1)))
+inline librtc_bool librtc_normalize( librtc_time *tm ) {
+	const long long seconds = librtc_to_unix_time( tm );
+	return librtc_from_unix_time( seconds, tm );
+}
+
+/* Formats a librtc_time struct into a textual representation using the format specifier.
+ * This function behaves identically to the strftime function from the C standard library.
+ * strftime documentation: https://en.cppreference.com/w/c/chrono/strftime
+ */
+__attribute__((format(strftime, 3, 0), nonnull(1, 3, 4), access(write_only, 1)))
+unsigned int librtc_strftime( char *str, unsigned int count, const char *format, const librtc_time *tp );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/lib/librtc/librtc.h
+++ b/lib/librtc/librtc.h
@@ -2,9 +2,6 @@
  * by Matt "falcobuster" Pharoah
  * https://gitlab.com/mpharoah/librtc
  * 
- * The proper 64 byte RTC commands needed to interface with the RTC were taken from libdragon
- * (https://github.com/DragonMinded/libdragon)
- * 
  * Public Domain (www.unlicense.org)
  * This is free and unencumbered software released into the public domain.
  * 
@@ -119,7 +116,7 @@ librtc_bool librtc_from_unix_time( long long unixTime, librtc_time *tm );
  * This function takes the offset (set with librtc_set_offset or librtc_set_time) into account.
  * This is more efficient than using librtc_get_time as it avoids needing to calculate leap days,
  * nor does it need to perform any 64-bit arithmetic.
- *
+ * 
  * Returns -1 if the flashcart or emulator does not support RTC.
  */
 __attribute__((warn_unused_result))

--- a/lib/librtc/librtc.h
+++ b/lib/librtc/librtc.h
@@ -16,8 +16,9 @@
 #define LIBRTC_H
 
 // <HackerSM64>
+#include "config/config_rom.h"
 #ifndef USE_RTC
-#error "librtc.h was included without enabling the RTC. Please set USE_RTC to 1 in the Makefile."
+#error "librtc.h was included without enabling the RTC. Please uncomment the USE_RTC define in config_rom.h"
 #endif
 // </HackerSM64>
 

--- a/lib/librtc/librtc.h
+++ b/lib/librtc/librtc.h
@@ -71,7 +71,7 @@ librtc_bool librtc_init();
  * passed since the RTC was initialized. Otherwise, returns true, even if RTC is not supported by the flashcart or emulator.
  *
  * On console, there is a 20 millisecond delay between initializing the RTC and when the time can first be fetched.
- * This delay exists to wokraround some buggy flashcarts that do not properly set the RTC status. To ensure that the RTC has had
+ * This delay exists to workaround some buggy flashcarts that do not properly set the RTC status. To ensure that the RTC has had
  * enough time to initialize on these buggy flashcarts, a 20 millisecond delay is enforced to avoid returning garbage data.
  *
  * NOTE: The COUNT register on the CPU is used to determine the time passed. Since this counter overflows every ~90 seconds,

--- a/lib/librtc/librtc.h
+++ b/lib/librtc/librtc.h
@@ -115,6 +115,16 @@ long long librtc_to_unix_time( const librtc_time *tm );
 __attribute__((nonnull(2), access(write_only, 2)))
 librtc_bool librtc_from_unix_time( long long unixTime, librtc_time *tm );
 
+/* Returns the current time as the number of seconds since the start of the day [0-86399].
+ * This function takes the offset (set with librtc_set_offset or librtc_set_time) into account.
+ * This is more efficient than using librtc_get_time as it avoids needing to calculate leap days,
+ * nor does it need to perform any 64-bit arithmetic.
+ *
+ * Returns -1 if the flashcart or emulator does not support RTC.
+ */
+__attribute__((warn_unused_result))
+int librtc_get_time_of_day();
+
 /* Adds a number of seconds to the calendar time and normalizes it.
  * The passed in struct is modified, and a pointer to the same struct is returned.
  */

--- a/sm64.ld
+++ b/sm64.ld
@@ -188,6 +188,9 @@ SECTIONS
 #ifdef LIBPL
       BUILD_DIR/lib/libpl*.o(.text*);
 #endif
+#ifdef USE_RTC
+      BUILD_DIR/lib/librtc*.o(.text*);
+#endif
       *ULTRALIB.a:*.o(.text*);
       */libnustd.a:*.o(.text*);
       *libgcc.a:*.o(.text*);
@@ -210,6 +213,9 @@ SECTIONS
 #ifdef LIBPL
       BUILD_DIR/lib/libpl*.o(.*data*);
 #endif
+#ifdef USE_RTC
+      BUILD_DIR/lib/librtc*.o(.*data*);
+#endif
       *ULTRALIB.a:*.o(.data*);
       */libhvqm2.a:*.o(.data*);
       */libz.a:*.o(.data*);
@@ -227,6 +233,9 @@ SECTIONS
 #endif
 #ifdef LIBPL
       BUILD_DIR/lib/libpl*.o(.rodata*);
+#endif
+#ifdef USE_RTC
+      BUILD_DIR/lib/librtc*.o(.rodata*);
 #endif
       *ULTRALIB.a:*.o(.rodata*);
       *libgcc.a:*.o(.rodata*);
@@ -246,6 +255,9 @@ SECTIONS
 #endif
 #ifdef LIBPL
       BUILD_DIR/lib/libpl*.o(.*bss*);
+#endif
+#ifdef USE_RTC
+      BUILD_DIR/lib/librtc*.o(.*bss*);
 #endif
       *ULTRALIB.a:*.o(COMMON);
       *ULTRALIB.a:*.o(.scommon);

--- a/sm64.ld
+++ b/sm64.ld
@@ -188,9 +188,7 @@ SECTIONS
 #ifdef LIBPL
       BUILD_DIR/lib/libpl*.o(.text*);
 #endif
-#ifdef USE_RTC
       BUILD_DIR/lib/librtc*.o(.text*);
-#endif
       *ULTRALIB.a:*.o(.text*);
       */libnustd.a:*.o(.text*);
       *libgcc.a:*.o(.text*);
@@ -213,9 +211,7 @@ SECTIONS
 #ifdef LIBPL
       BUILD_DIR/lib/libpl*.o(.*data*);
 #endif
-#ifdef USE_RTC
       BUILD_DIR/lib/librtc*.o(.*data*);
-#endif
       *ULTRALIB.a:*.o(.data*);
       */libhvqm2.a:*.o(.data*);
       */libz.a:*.o(.data*);
@@ -234,9 +230,7 @@ SECTIONS
 #ifdef LIBPL
       BUILD_DIR/lib/libpl*.o(.rodata*);
 #endif
-#ifdef USE_RTC
       BUILD_DIR/lib/librtc*.o(.rodata*);
-#endif
       *ULTRALIB.a:*.o(.rodata*);
       *libgcc.a:*.o(.rodata*);
       */libz.a:*.o(.rodata*);
@@ -256,9 +250,7 @@ SECTIONS
 #ifdef LIBPL
       BUILD_DIR/lib/libpl*.o(.*bss*);
 #endif
-#ifdef USE_RTC
       BUILD_DIR/lib/librtc*.o(.*bss*);
-#endif
       *ULTRALIB.a:*.o(COMMON);
       *ULTRALIB.a:*.o(.scommon);
       *ULTRALIB.a:*.o(.*bss*);


### PR DESCRIPTION
I split off the RTC support from my n64-libc library to make it own smaller librtc library that's just a single source file plus a header file.

Added it to 3.0.0 and updated the ROM header to set the RTC bit when enabled.