### PR TITLE
Fix deflate buffers overrunning decompressor context

### DIFF
--- a/src/boot/memory.c
+++ b/src/boot/memory.c
@@ -5,6 +5,7 @@
 #include "buffers/buffers.h"
 #include "dma_async.h"
 #include "slidec.h"
+#include "game/debug.h"
 #include "game/game_init.h"
 #include "game/main.h"
 #include "game/memory.h"
@@ -389,6 +390,7 @@ void *load_segment_decompress(s32 segment, u8 *srcStart, u8 *srcEnd) {
 
 #ifdef GZIP
     struct libdeflate_decompressor *dec = libdeflate_alloc_decompressor();
+    aggress(dec != NULL, "Failed to allocate GZIP decompressor!");
 #endif
 
     u8 *compressed = main_pool_alloc(compSize, MEMORY_POOL_RIGHT);
@@ -430,7 +432,9 @@ void *load_segment_decompress(s32 segment, u8 *srcStart, u8 *srcEnd) {
     }
 
 #ifdef GZIP
-    libdeflate_free_decompressor(dec);
+    if (dec) {
+        libdeflate_free_decompressor(dec);
+    }
 #endif
 
 #ifdef PUPPYPRINT_DEBUG

--- a/src/boot/memory.c
+++ b/src/boot/memory.c
@@ -386,6 +386,11 @@ void *load_segment_decompress(s32 segment, u8 *srcStart, u8 *srcEnd) {
     void *dest = NULL;
 
     u32 compSize = ALIGN16(srcEnd - srcStart);
+
+#ifdef GZIP
+    struct libdeflate_decompressor *dec = libdeflate_alloc_decompressor();
+#endif
+
     u8 *compressed = main_pool_alloc(compSize, MEMORY_POOL_RIGHT);
     // Decompressed size from header (This works for non-mio0 because they also have the size in same place)
     u32 *size = (u32 *) (compressed + 4);
@@ -406,9 +411,7 @@ void *load_segment_decompress(s32 segment, u8 *srcStart, u8 *srcEnd) {
         if (dest != NULL) {
             osSyncPrintf("start decompress\n");
 #ifdef GZIP
-            struct libdeflate_decompressor *dec = libdeflate_alloc_decompressor();
             libdeflate_deflate_decompress(dec, compressed + 16, *(u32*) (compressed + 8), dest, &asyncCtx);
-            libdeflate_free_decompressor(dec);
 #elif RNC1
             Propack_UnpackM1(compressed, dest);
 #elif RNC2
@@ -425,6 +428,11 @@ void *load_segment_decompress(s32 segment, u8 *srcStart, u8 *srcEnd) {
             main_pool_free(compressed);
         }
     }
+
+#ifdef GZIP
+    libdeflate_free_decompressor(dec);
+#endif
+
 #ifdef PUPPYPRINT_DEBUG
     u32 ppSize = ALIGN16((u32)*size) + 16;
     set_segment_memory_printout(segment, ppSize);


### PR DESCRIPTION
Reland #896 with proper fix for "free" sequence. This is needed to support very large decompressed content that can overrun the compressed data.

This works for protocols that supports data "streaming" - for example GZIP/ LZ4T/YAY0 are "streaming" protocols, MIO0 is NOT "streaming" protocol because it has 2 cursors.

The layout in memory will look like this, decompressed data will not overrun the "ctx" that should be allocated first.
<img width="1257" height="254" alt="image" src="https://github.com/user-attachments/assets/d4e0bff4-8e10-4648-b79f-0251c734b44b" />
