### PR TITLE
Only run ROM extraction tools once on every make invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,6 +318,7 @@ ifeq ($(filter clean distclean print-%,$(MAKECMDGOALS)),)
     $(eval $(call find-rom,jp))
     $(eval $(call find-rom,eu))
     $(eval $(call find-rom,sh))
+    $(info Found Baseroms: [$(EXTRACT_ASSETS_VERSIONS)])
     DUMMY != $(PYTHON) extract_assets.py $(EXTRACT_ASSETS_VERSIONS) >&2 || echo FAIL
     ifeq ($(DUMMY),FAIL)
       $$(error Failed to extract assets from $1 ROM)

--- a/Makefile
+++ b/Makefile
@@ -314,28 +314,10 @@ ifeq ($(filter clean distclean print-%,$(MAKECMDGOALS)),)
   # Make sure assets exist
   NOEXTRACT ?= 0
   ifeq ($(NOEXTRACT),0)
-    DUMMY != $(PYTHON) extract_assets.py us >&2 || echo FAIL
-    ifeq ($(DUMMY),FAIL)
-      $(error Failed to extract assets from US ROM)
-    endif
-    ifneq (,$(shell python3 tools/detect_baseroms.py jp))
-      DUMMY != $(PYTHON) extract_assets.py jp >&2 || echo FAIL
-      ifeq ($(DUMMY),FAIL)
-        $(error Failed to extract assets from JP ROM)
-      endif
-    endif
-    ifneq (,$(shell python3 tools/detect_baseroms.py eu))
-      DUMMY != $(PYTHON) extract_assets.py eu >&2 || echo FAIL
-      ifeq ($(DUMMY),FAIL)
-        $(error Failed to extract assets from EU ROM)
-      endif
-    endif
-    ifneq (,$(shell python3 tools/detect_baseroms.py sh))
-      DUMMY != $(PYTHON) extract_assets.py sh >&2 || echo FAIL
-      ifeq ($(DUMMY),FAIL)
-        $(error Failed to extract assets from SH ROM)
-      endif
-    endif
+    $(eval $(call extract-assets,us))
+    $(eval $(call extract-assets,jp))
+    $(eval $(call extract-assets,eu))
+    $(eval $(call extract-assets,sh))
   endif
 
   # Make tools if out of date

--- a/Makefile
+++ b/Makefile
@@ -311,13 +311,17 @@ PYTHON := python3
 
 ifeq ($(filter clean distclean print-%,$(MAKECMDGOALS)),)
 
-  # Make sure assets exist
+  # Extract assets if necessary
   NOEXTRACT ?= 0
   ifeq ($(NOEXTRACT),0)
-    $(eval $(call extract-assets,us))
-    $(eval $(call extract-assets,jp))
-    $(eval $(call extract-assets,eu))
-    $(eval $(call extract-assets,sh))
+    $(eval $(call find-rom,us))
+    $(eval $(call find-rom,jp))
+    $(eval $(call find-rom,eu))
+    $(eval $(call find-rom,sh))
+    DUMMY != $(PYTHON) extract_assets.py $(EXTRACT_ASSETS_VERSIONS) >&2 || echo FAIL
+    ifeq ($(DUMMY),FAIL)
+      $$(error Failed to extract assets from $1 ROM)
+    endif
   endif
 
   # Make tools if out of date

--- a/Makefile
+++ b/Makefile
@@ -318,7 +318,6 @@ ifeq ($(filter clean distclean print-%,$(MAKECMDGOALS)),)
     $(eval $(call find-rom,jp))
     $(eval $(call find-rom,eu))
     $(eval $(call find-rom,sh))
-    $(info Found Baseroms: [$(EXTRACT_ASSETS_VERSIONS)])
     DUMMY != $(PYTHON) extract_assets.py $(EXTRACT_ASSETS_VERSIONS) >&2 || echo FAIL
     ifeq ($(DUMMY),FAIL)
       $$(error Failed to extract assets from $1 ROM)

--- a/Makefile
+++ b/Makefile
@@ -314,9 +314,9 @@ ifeq ($(filter clean distclean print-%,$(MAKECMDGOALS)),)
   # Extract assets if necessary
   NOEXTRACT ?= 0
   ifeq ($(NOEXTRACT),0)
-    DUMMY != $(PYTHON) extract_assets.py $(shell $(PYTHON) tools/detect_baseroms.py list) >&2 || echo FAIL
+    DUMMY != $(PYTHON) extract_assets.py >&2 || echo FAIL
     ifeq ($(DUMMY),FAIL)
-      $$(error Failed to extract assets from $1 ROM)
+      $(error Failed to extract assets from found baseroms)
     endif
   endif
 

--- a/Makefile
+++ b/Makefile
@@ -314,11 +314,7 @@ ifeq ($(filter clean distclean print-%,$(MAKECMDGOALS)),)
   # Extract assets if necessary
   NOEXTRACT ?= 0
   ifeq ($(NOEXTRACT),0)
-    $(eval $(call find-rom,us))
-    $(eval $(call find-rom,jp))
-    $(eval $(call find-rom,eu))
-    $(eval $(call find-rom,sh))
-    DUMMY != $(PYTHON) extract_assets.py $(EXTRACT_ASSETS_VERSIONS) >&2 || echo FAIL
+    DUMMY != $(PYTHON) extract_assets.py $(shell $(PYTHON) tools/detect_baseroms.py list) >&2 || echo FAIL
     ifeq ($(DUMMY),FAIL)
       $$(error Failed to extract assets from $1 ROM)
     endif

--- a/extract_assets.py
+++ b/extract_assets.py
@@ -125,7 +125,7 @@ def main():
     romLUT = get_rom_candidates()
 
     if not langs:
-        langs = [version for version in romLUT]
+        langs = romLUT.keys()
 
     # verify the correct rom
     for lang in langs:

--- a/extract_assets.py
+++ b/extract_assets.py
@@ -134,7 +134,7 @@ def main():
         sys.exit(1)
 
     # Late imports (to optimize startup perf)
-    import hashlib
+    # import hashlib
     import tempfile
     from collections import defaultdict
 

--- a/extract_assets.py
+++ b/extract_assets.py
@@ -4,7 +4,7 @@ import os
 import json
 import subprocess
 
-from tools.detect_baseroms import get_rom_candidates
+from tools.detect_baseroms import get_rom_candidates, ROMS_DIR
 
 envmap_table = set([
     "actors/mario/mario_metal.rgba16.png",
@@ -73,6 +73,15 @@ def clean_assets(local_asset_file):
         except FileNotFoundError:
             pass
 
+def usage():
+    all_langs = ["jp", "us", "eu", "sh"]
+    langs_str = " ".join("[" + lang + "]" for lang in all_langs)
+    print("Usage: ")
+    print(f"    Show this help message:          {sys.argv[0]} --help")
+    print(f"    Extract from all found baseroms: {sys.argv[0]}")
+    print(f"    Extract from specified versions: {sys.argv[0]} {langs_str}")
+    print(f"        (For each version, its ROM file must exist,")
+    print(f"            either in this folder or {ROMS_DIR}/)")
 
 def main():
     # In case we ever need to change formats of generated files, we keep a
@@ -90,6 +99,9 @@ def main():
     langs = sys.argv[1:]
     if langs == ["--clean"]:
         clean_assets(local_asset_file)
+        sys.exit(0)
+    elif langs == ["--help"] or langs == ["-h"]:
+        usage()
         sys.exit(0)
 
     asset_map = read_asset_map()
@@ -112,6 +124,8 @@ def main():
 
     romLUT = get_rom_candidates()
 
+    if not langs:
+        langs = [version for version in romLUT]
 
     # verify the correct rom
     for lang in langs:

--- a/extract_assets.py
+++ b/extract_assets.py
@@ -148,7 +148,6 @@ def main():
         sys.exit(1)
 
     # Late imports (to optimize startup perf)
-    # import hashlib
     import tempfile
     from collections import defaultdict
 

--- a/tools/deflatepack.c
+++ b/tools/deflatepack.c
@@ -34,14 +34,14 @@ static struct SizedBuffer readFile(const char* filename, int margin)
     }
 
     fseek(in, 0, SEEK_END);
-    size_t size = ftell(in);
+    long size = ftell(in);
     fseek(in, 0, SEEK_SET);
     char* buffer = malloc(size + margin);
     size_t fread_result = fread(buffer, size, 1, in);
     fclose(in);
     if (1 != fread_result)
     {
-        printf("Failed to read input file '%s': %lu != %lu\n", filename, fread_result, size);
+        printf("Failed to read input file '%s': %lu != %ld\n", filename, fread_result, size);
         abort();
     }
 

--- a/tools/deflatepack.c
+++ b/tools/deflatepack.c
@@ -34,14 +34,14 @@ static struct SizedBuffer readFile(const char* filename, int margin)
     }
 
     fseek(in, 0, SEEK_END);
-    int size = ftell(in);
+    size_t size = ftell(in);
     fseek(in, 0, SEEK_SET);
     char* buffer = malloc(size + margin);
     size_t fread_result = fread(buffer, size, 1, in);
     fclose(in);
     if (1 != fread_result)
     {
-        printf("Failed to read input file '%s': %d != %d\n", filename, fread_result, size);
+        printf("Failed to read input file '%s': %lu != %lu\n", filename, fread_result, size);
         abort();
     }
 

--- a/tools/detect_baseroms.py
+++ b/tools/detect_baseroms.py
@@ -19,6 +19,9 @@ sha1_swapLUT = {
     "us": "1002dd7b56aa0a59a9103f1fb3d57d6b161f8da7",
 }
 
+def usage():
+    print(f"Usage: {sys.argv[0]} command (find-baserom list-available-versions) version (us jp eu sh)")
+
 def get_rom_candidates():
     fileArray = [f for f in os.listdir(os.getcwd()) if os.path.isfile(f)]
     if os.path.exists(ROMS_DIR):
@@ -55,7 +58,7 @@ def get_rom_candidates():
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print(f"Usage: {sys.argv[0]} version (us jp eu sh)")
+        usage()
         sys.exit(1)
     gamelist = get_rom_candidates();
     version = sys.argv[1]

--- a/tools/detect_baseroms.py
+++ b/tools/detect_baseroms.py
@@ -36,9 +36,9 @@ def get_rom_candidates():
             with open(baseromCandidate, "rb") as romFile:
                 sha1sum = sha1(romFile.read()).hexdigest()
 
-            for k, v in sha1_LUT.items():
-                if v == sha1sum:
-                    foundVersions[k] = baseromCandidate
+            for version, sha in sha1_LUT.items():
+                if sha == sha1sum:
+                    foundVersions[version] = baseromCandidate
 
             for version, sha in sha1_swapLUT.items():
                 if sha == sha1sum: # the ROM is swapped!

--- a/tools/detect_baseroms.py
+++ b/tools/detect_baseroms.py
@@ -3,73 +3,94 @@ import os
 import sys
 from hashlib import sha1
 
-XDG_DATA_DIR=os.environ.get("XDG_DATA_HOME") or "~/.local/share"
-ROMS_DIR=os.path.expanduser(os.path.join(XDG_DATA_DIR, "HackerSM64"))
+XDG_DATA_DIR: str = os.environ.get("XDG_DATA_HOME") or "~/.local/share"
+ROMS_DIR: str = os.path.expanduser(os.path.join(XDG_DATA_DIR, "HackerSM64"))
 
-sha1_LUT = {
+sha1_LUT: dict[str, int] = {
     "eu": "4ac5721683d0e0b6bbb561b58a71740845dceea9",
     "jp": "8a20a5c83d6ceb0f0506cfc9fa20d8f438cafe51",
     "sh": "3f319ae697533a255a1003d09202379d78d5a2e0",
     "us": "9bef1128717f958171a4afac3ed78ee2bb4e86ce",
 }
 
-sha1_swapLUT = {
+sha1_swapLUT: dict[str, str] = {
     "eu": "d80ee9eeb6454d53a96ceb6ed0aca3ffde045091",
     "jp": "1d2579dd5fb1d8263a4bcc063a651a64acc88921",
     "sh": "2a2b85e94581545ca3c05b8f864b488b141a8a1f",
     "us": "1002dd7b56aa0a59a9103f1fb3d57d6b161f8da7",
 }
 
-def usage():
+
+def usage() -> None:
+    """
+    Print program usage.
+    """
     print(f"Usage: {sys.argv[0]} version (us jp eu sh list)")
 
-def get_rom_candidates():
-    fileArray = [f for f in os.listdir(os.getcwd()) if os.path.isfile(f)]
+
+def get_rom_candidates() -> dict[str, str]:
+    """
+    Search the working directory and the global baserom directory for files,
+     then compare hashes of those files with known SHA1's. If a file matches a
+     swapped SHA1, then invoke `dd` to perform a byteswap to a temp folder.
+
+    Returns a dictionary where the key is a version string,
+      and the value is the ROM found for that version
+    """
+    fileArray: list[str] = [f for f in os.listdir(os.getcwd()) if os.path.isfile(f)]
     if os.path.exists(ROMS_DIR):
-        fileArray += [os.path.join(ROMS_DIR, f) for f in os.listdir(ROMS_DIR) if os.path.isfile(os.path.join(ROMS_DIR, f))]
+        fileArray += [
+            os.path.join(ROMS_DIR, f)
+            for f in os.listdir(ROMS_DIR)
+            if os.path.isfile(os.path.join(ROMS_DIR, f))
+        ]
 
-    foundVersions = {}
+    foundVersions: dict[str, str] = {}
 
+    baseromCandidate: str
     for baseromCandidate in fileArray:
         try:
-            sha1sum = 0
+            sha1sum: str = ""
             with open(baseromCandidate, "rb") as romFile:
                 sha1sum = sha1(romFile.read()).hexdigest()
 
+            version: str
+            sha: str
             for version, sha in sha1_LUT.items():
                 if sha == sha1sum:
                     foundVersions[version] = baseromCandidate
 
+            version: str
+            sha: str
             for version, sha in sha1_swapLUT.items():
-                if sha == sha1sum: # the ROM is swapped!
+                if sha == sha1sum:  # the ROM is swapped!
                     if not os.path.isfile(f"/tmp/baserom.{version}.swapped.z64"):
                         # Only swap the ROM if it doesn't exist
                         subprocess.run(
                             [
-                                "dd","conv=swab",
+                                "dd",
+                                "conv=swab",
                                 f"if={baseromCandidate}",
-                                f"of=/tmp/baserom.{version}.swapped.z64"
+                                f"of=/tmp/baserom.{version}.swapped.z64",
                             ],
                             stderr=subprocess.PIPE,
                         )
                     foundVersions[version] = f"/tmp/baserom.{version}.swapped.z64"
-        except Exception as e:
+        except Exception:
+            # Just skip the file if anything goes wrong
             continue
     return foundVersions
-
-def list_rom_candidates():
-    return [version for version in get_rom_candidates()]
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
         usage()
         sys.exit(1)
-    gamelist = get_rom_candidates();
+    gamelist = get_rom_candidates()
     version = sys.argv[1]
 
     if version == "list":
-        print(" ".join(list_rom_candidates()))
+        # List all found versions
+        print(" ".join(gamelist.keys()))
     elif version in gamelist:
+        # List the ROM found for a given version, if it exists
         print(gamelist[version])
-
-

--- a/tools/detect_baseroms.py
+++ b/tools/detect_baseroms.py
@@ -30,15 +30,15 @@ def get_rom_candidates():
 
     foundVersions = {}
 
-    for f in fileArray:
+    for baseromCandidate in fileArray:
         try:
             sha1sum = 0
-            with open(f, "rb") as romFile:
+            with open(baseromCandidate, "rb") as romFile:
                 sha1sum = sha1(romFile.read()).hexdigest()
 
             for k, v in sha1_LUT.items():
                 if v == sha1sum:
-                    foundVersions[k] = f
+                    foundVersions[k] = baseromCandidate
 
             for version, sha in sha1_swapLUT.items():
                 if sha == sha1sum: # the ROM is swapped!
@@ -47,7 +47,7 @@ def get_rom_candidates():
                         subprocess.run(
                             [
                                 "dd","conv=swab",
-                                "if=%s" % f,
+                                f"if={baseromCandidate}",
                                 f"of=/tmp/baserom.{version}.swapped.z64"
                             ],
                             stderr=subprocess.PIPE,

--- a/tools/detect_baseroms.py
+++ b/tools/detect_baseroms.py
@@ -21,7 +21,7 @@ sha1_swapLUT = {
 }
 
 def usage():
-    print(f"Usage: {sys.argv[0]} command version (us jp eu sh)")
+    print(f"Usage: {sys.argv[0]} version (us jp eu sh list)")
 
 def get_rom_candidates():
     fileArray = [f for f in os.listdir(os.getcwd()) if os.path.isfile(f)]
@@ -65,7 +65,9 @@ if __name__ == "__main__":
     gamelist = get_rom_candidates();
     version = sys.argv[1]
 
-    if version in gamelist:
+    if version == "list":
+        print(" ".join([version for version in gamelist]))
+    elif version in gamelist:
         print(gamelist[version])
 
 

--- a/tools/detect_baseroms.py
+++ b/tools/detect_baseroms.py
@@ -1,6 +1,7 @@
 import subprocess
 import os
 import sys
+from hashlib import sha1
 
 XDG_DATA_DIR=os.environ.get("XDG_DATA_HOME") or "~/.local/share"
 ROMS_DIR=os.path.expanduser(os.path.join(XDG_DATA_DIR, "HackerSM64"))
@@ -20,7 +21,7 @@ sha1_swapLUT = {
 }
 
 def usage():
-    print(f"Usage: {sys.argv[0]} command (find-baserom list-available-versions) version (us jp eu sh)")
+    print(f"Usage: {sys.argv[0]} command version (us jp eu sh)")
 
 def get_rom_candidates():
     fileArray = [f for f in os.listdir(os.getcwd()) if os.path.isfile(f)]
@@ -31,26 +32,27 @@ def get_rom_candidates():
 
     for f in fileArray:
         try:
-            p = subprocess.Popen(
-                ["sha1sum", f],
-                stdout=subprocess.PIPE
-            )
-            sha1sum = p.communicate()[0].decode('ascii').split()[0]
+            sha1sum = 0
+            with open(f, "rb") as romFile:
+                sha1sum = sha1(romFile.read()).hexdigest()
+
             for k, v in sha1_LUT.items():
                 if v == sha1sum:
                     foundVersions[k] = f
 
-            for k, v in sha1_swapLUT.items():
-                if v == sha1sum: # the ROM is swapped!
-                    subprocess.run(
-                        [
-                            "dd","conv=swab",
-                            "if=%s" % f,
-                            "of=/tmp/baserom.%s.swapped.z64" % k
-                        ],
-                        stderr=subprocess.PIPE,
-                    )
-                    foundVersions[k] = "/tmp/baserom.%s.swapped.z64" % k
+            for version, sha in sha1_swapLUT.items():
+                if sha == sha1sum: # the ROM is swapped!
+                    if not os.path.isfile(f"/tmp/baserom.{version}.swapped.z64"):
+                        # Only swap the ROM if it doesn't exist
+                        subprocess.run(
+                            [
+                                "dd","conv=swab",
+                                "if=%s" % f,
+                                f"of=/tmp/baserom.{version}.swapped.z64"
+                            ],
+                            stderr=subprocess.PIPE,
+                        )
+                    foundVersions[version] = f"/tmp/baserom.{version}.swapped.z64"
         except Exception as e:
             continue
     return foundVersions

--- a/tools/detect_baseroms.py
+++ b/tools/detect_baseroms.py
@@ -57,6 +57,8 @@ def get_rom_candidates():
             continue
     return foundVersions
 
+def list_rom_candidates():
+    return [version for version in get_rom_candidates()]
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
@@ -66,7 +68,7 @@ if __name__ == "__main__":
     version = sys.argv[1]
 
     if version == "list":
-        print(" ".join([version for version in gamelist]))
+        print(" ".join(list_rom_candidates()))
     elif version in gamelist:
         print(gamelist[version])
 

--- a/util.mk
+++ b/util.mk
@@ -1,13 +1,11 @@
 # util.mk - Miscellaneous utility functions for use in Makefiles
 
-# Checks if the assets have been extracted
-define extract-assets
+# Usage: $(call find-rom,[us|eu|jp|sh])
+# Appends the EXTRACT_ASSETS_VERSIONS variable if rom version is found
+define find-rom
   ifneq (,$$(shell python3 tools/detect_baseroms.py $1))
-    $(warning "Extracting assets from $1 ROM...\n")
-    DUMMY != $$(PYTHON) extract_assets.py $1 >&2 || echo FAIL
-    ifeq ($$(DUMMY),FAIL)
-      $$(error Failed to extract assets from $1 ROM)
-    endif
+    $(info Locating ROM for region $1...)
+    EXTRACT_ASSETS_VERSIONS += $1
   endif
 endef
 

--- a/util.mk
+++ b/util.mk
@@ -4,7 +4,6 @@
 # Appends the EXTRACT_ASSETS_VERSIONS variable if rom version is found
 define find-rom
   ifneq (,$$(shell python3 tools/detect_baseroms.py $1))
-    $(info Locating ROM for region $1...)
     EXTRACT_ASSETS_VERSIONS += $1
   endif
 endef

--- a/util.mk
+++ b/util.mk
@@ -1,5 +1,16 @@
 # util.mk - Miscellaneous utility functions for use in Makefiles
 
+# Checks if the assets have been extracted
+define extract-assets
+  ifneq (,$$(shell python3 tools/detect_baseroms.py $1))
+      $(warning "Extracting assets from $1 ROM...\n")
+      DUMMY != $$(PYTHON) extract_assets.py $1 >&2 || echo FAIL
+      ifeq ($$(DUMMY),FAIL)
+        $$(error Failed to extract assets from $1 ROM)
+      endif
+  endif
+endef
+
 # Throws an error if the value of the variable named by $(1) is not in the list given by $(2)
 define validate-option
   # value must be part of the list

--- a/util.mk
+++ b/util.mk
@@ -1,13 +1,5 @@
 # util.mk - Miscellaneous utility functions for use in Makefiles
 
-# Usage: $(call find-rom,[us|eu|jp|sh])
-# Appends the EXTRACT_ASSETS_VERSIONS variable if rom version is found
-define find-rom
-  ifneq (,$$(shell python3 tools/detect_baseroms.py $1))
-    EXTRACT_ASSETS_VERSIONS += $1
-  endif
-endef
-
 # Throws an error if the value of the variable named by $(1) is not in the list given by $(2)
 define validate-option
   # value must be part of the list

--- a/util.mk
+++ b/util.mk
@@ -3,11 +3,11 @@
 # Checks if the assets have been extracted
 define extract-assets
   ifneq (,$$(shell python3 tools/detect_baseroms.py $1))
-      $(warning "Extracting assets from $1 ROM...\n")
-      DUMMY != $$(PYTHON) extract_assets.py $1 >&2 || echo FAIL
-      ifeq ($$(DUMMY),FAIL)
-        $$(error Failed to extract assets from $1 ROM)
-      endif
+    $(warning "Extracting assets from $1 ROM...\n")
+    DUMMY != $$(PYTHON) extract_assets.py $1 >&2 || echo FAIL
+    ifeq ($$(DUMMY),FAIL)
+      $$(error Failed to extract assets from $1 ROM)
+    endif
   endif
 endef
 


### PR DESCRIPTION
We are addressing #834 

- Introduce a new util function, `find-rom`, as a wrapper for detect_baseroms.py
- In detect_baseroms.py itself, use the built-in `hashlib` sha1 instead of invoking a subprocess for every file in the top-level directory
- Skip `dd` invocation if swapped baserom already exists in `/tmp`