### PR TITLE
Add system capabilities variable that tracks individual features instead of broad emulator support

### DIFF
--- a/src/boot/main.c
+++ b/src/boot/main.c
@@ -350,9 +350,6 @@ void thread3_main(UNUSED void *arg) {
     alloc_pool();
     load_engine_code_segment();
     gEmulator = detect_emulator();
-    if (emulator_supports_trap_instructions(gEmulator)) {
-        check_emux_support();
-    }
 #ifndef UNF
     crash_screen_init();
 #endif

--- a/src/boot/main.c
+++ b/src/boot/main.c
@@ -350,6 +350,9 @@ void thread3_main(UNUSED void *arg) {
     alloc_pool();
     load_engine_code_segment();
     gEmulator = detect_emulator();
+    if (emulator_supports_trap_instructions(gEmulator)) {
+        check_emux_support();
+    }
 #ifndef UNF
     crash_screen_init();
 #endif

--- a/src/game/emutest.c
+++ b/src/game/emutest.c
@@ -84,6 +84,9 @@ u32 detect_emulator() {
         // libpl is supported. Must be ParallelN64
 #ifdef LIBPL
         gSupportsLibpl = libpl_is_supported(LPL_ABI_VERSION_CURRENT);
+        if (gSupportsLibpl) {
+            gSystemCapabilities |= SYS_SUPPORTS_LIBPL;
+        }
 #endif
         return EMU_PARALLEL_LAUNCHER;
     }
@@ -107,11 +110,14 @@ u32 detect_emulator() {
     if (1.0f != round_double_to_float(0.9999999999999999)) {
         fcr_set_rounding_mode(roundingMode);
         return EMU_WIIVC;
+    } else {
+        gSystemCapabilities |= SYS_SUPPORTS_FLOAT_ROUNDING_MODE;
     }
     fcr_set_rounding_mode(roundingMode);
 
     // If cache is emulated, then this is likely Simple64, or some other accurate emulator.
     if (check_cache_emulation()) {
+        gSystemCapabilities |= SYS_SUPPORTS_CACHE;
         return EMU_OTHER;
     }
 
@@ -151,15 +157,3 @@ u32 detect_emulator() {
     // Note that Project64 4.0 will be detected here.
     return EMU_OTHER;
 } 
-
-void self_test_system_capabilities(void) {
-    if (check_cache_emulation()) {
-        gSystemCapabilities |= SYS_SUPPORTS_CACHE;
-    }
-#ifdef LIBPL
-    if (libpl_is_supported(LPL_ABI_VERSION_CURRENT)) {
-        gSystemCapabilities |= SYS_SUPPORTS_LIBPL;
-    }
-#endif // LIBPL
-
-}

--- a/src/game/emutest.c
+++ b/src/game/emutest.c
@@ -114,6 +114,12 @@ u32 detect_emulator() {
 #ifdef LIBPL
     // We have libpl downloaded as a submodule, just use the API call.
     if (libpl_is_supported(LPL_ABI_VERSION_CURRENT)) {
+        const lpl_plugin_info *plugin_info = libpl_get_graphics_plugin();
+
+        // We can query framebuffer emulation from libpl
+        if (plugin_info->capabilities & LPL_FRAMEBUFFER_EMULATION) {
+            gSystemCapabilities |= SUPPORTS_SOFTWARE_FRAMEBUFFER;
+        }
 #else // LIBPL
     // libpl interacts with the hardware register at 0x1FFB0000,
     //  so we can still _detect_ it by clearing the register and
@@ -129,6 +135,8 @@ u32 detect_emulator() {
 
     // If DPC registers are emulated, this is either console or a very accurate emulator
     if ((u32)IO_READ(DPC_PIPEBUSY_REG) | (u32)IO_READ(DPC_TMEM_REG) | (u32)IO_READ(DPC_BUFBUSY_REG)) {
+        // Assume we have the ability to manipulate the framebuffer too.
+        gSystemCapabilities |= SUPPORTS_SOFTWARE_FRAMEBUFFER;
         return EMU_CONSOLE;
     }
     

--- a/src/game/emutest.c
+++ b/src/game/emutest.c
@@ -77,6 +77,7 @@ static u8 check_cache_emulation() {
 static void check_emux_support(void) {
     volatile u32 hasExtensions = 0;
 
+    // run `emux detect`
     asm volatile(
         "tne %0, %0"
         : "=r" (hasExtensions) // Outputs

--- a/src/game/emutest.c
+++ b/src/game/emutest.c
@@ -75,11 +75,11 @@ static u8 check_cache_emulation() {
 }
 
 static void check_emux_support(void) {
-    u64 hasExtensions = 0;
+    volatile u32 hasExtensions = 0;
 
     asm volatile(
         "tne %0, %0"
-    : // no outputs
+    : "=r" (hasExtensions) // Outputs
     : "r" (hasExtensions) // Inputs
     : // no clobbers
     );

--- a/src/game/emutest.c
+++ b/src/game/emutest.c
@@ -79,9 +79,9 @@ static void check_emux_support(void) {
 
     asm volatile(
         "tne %0, %0"
-    : "=r" (hasExtensions) // Outputs
-    : "r" (hasExtensions) // Inputs
-    : // no clobbers
+        : "=r" (hasExtensions) // Outputs
+        : "r" (hasExtensions) // Inputs
+        : // no clobbers
     );
 
     if (hasExtensions) {

--- a/src/game/emutest.c
+++ b/src/game/emutest.c
@@ -80,7 +80,7 @@ static void check_emux_support(void) {
     asm volatile(
         "tne %0, %0"
     : // no outputs
-    : "=r" (hasExtensions) // Inputs
+    : "r" (hasExtensions) // Inputs
     : // no clobbers
     );
 

--- a/src/game/emutest.c
+++ b/src/game/emutest.c
@@ -96,10 +96,10 @@ void check_emux_support(void) {
 //  Thus, we need to guard running `emux` detection behind valid systems.
 // Returns TRUE if an emulator won't crash trying to detect `emux` functionality.
 u32 emulator_supports_trap_instructions(u32 emulator) {
-    if (gEmulator & EMU_PROJECT64_1_OR_2) {
+    if (emulator & EMU_PROJECT64_1_OR_2) {
         return FALSE;
     }
-    if (gEmulator & EMU_WIIVC) {
+    if (emulator & EMU_WIIVC) {
         return FALSE;
     }
 

--- a/src/game/emutest.c
+++ b/src/game/emutest.c
@@ -109,17 +109,21 @@ u32 emulator_supports_trap_instructions(u32 emulator) {
 // Tests various system quirks and initializes gEmulator to the detected emulator(s).
 //  Also initializes gSystemCapabilities.
 u32 detect_emulator() {
-    // Test to see if the libpl emulator extension is present.
     u32 magic;
+    // Test to see if the libpl emulator extension is present.
+#ifdef LIBPL
+    // We have libpl downloaded as a submodule, just use the API call.
+    if (libpl_is_supported(LPL_ABI_VERSION_CURRENT)) {
+#else // LIBPL
+    // libpl interacts with the hardware register at 0x1FFB0000,
+    //  so we can still _detect_ it by clearing the register and
+    //  seeing if we get a specific value back.
     osPiWriteIo(0x1ffb0000u, 0u);
     osPiReadIo(0x1ffb0000u, &magic);
     if (magic == 0x00500000u) {
-        // libpl is supported. Must be ParallelN64
-#ifdef LIBPL
-        if (libpl_is_supported(LPL_ABI_VERSION_CURRENT)) {
-            gSystemCapabilities |= SUPPORTS_LIBPL;
-        }
-#endif
+#endif // LIBPL
+        gSystemCapabilities |= SUPPORTS_LIBPL;
+        // If libpl is supported, we're on Parallel Launcher
         return EMU_PARALLEL_LAUNCHER;
     }
 

--- a/src/game/emutest.c
+++ b/src/game/emutest.c
@@ -23,7 +23,6 @@ extern void __osPiGetAccess(void);
 extern void __osPiRelAccess(void);
 
 u8 gEmulator = EMU_CONSOLE;
-u8 gSupportsLibpl = FALSE;
 u32 gSystemCapabilities = 0;
 
 static inline u32 get_pj64_version() {
@@ -83,8 +82,7 @@ u32 detect_emulator() {
     if (magic == 0x00500000u) {
         // libpl is supported. Must be ParallelN64
 #ifdef LIBPL
-        gSupportsLibpl = libpl_is_supported(LPL_ABI_VERSION_CURRENT);
-        if (gSupportsLibpl) {
+        if (libpl_is_supported(LPL_ABI_VERSION_CURRENT)) {
             gSystemCapabilities |= SYS_SUPPORTS_LIBPL;
         }
 #endif

--- a/src/game/emutest.c
+++ b/src/game/emutest.c
@@ -83,7 +83,7 @@ u32 detect_emulator() {
         // libpl is supported. Must be ParallelN64
 #ifdef LIBPL
         if (libpl_is_supported(LPL_ABI_VERSION_CURRENT)) {
-            gSystemCapabilities |= SYS_SUPPORTS_LIBPL;
+            gSystemCapabilities |= SYSCAP_LIBPL;
         }
 #endif
         return EMU_PARALLEL_LAUNCHER;
@@ -109,13 +109,13 @@ u32 detect_emulator() {
         fcr_set_rounding_mode(roundingMode);
         return EMU_WIIVC;
     } else {
-        gSystemCapabilities |= SYS_SUPPORTS_FLOAT_ROUNDING_MODE;
+        gSystemCapabilities |= SYSCAP_FLOAT_ROUNDING_MODE;
     }
     fcr_set_rounding_mode(roundingMode);
 
     // If cache is emulated, then this is likely Simple64, or some other accurate emulator.
     if (check_cache_emulation()) {
-        gSystemCapabilities |= SYS_SUPPORTS_CACHE;
+        gSystemCapabilities |= SYSCAP_CACHE;
         return EMU_OTHER;
     }
 

--- a/src/game/emutest.c
+++ b/src/game/emutest.c
@@ -74,38 +74,6 @@ static u8 check_cache_emulation() {
     return cacheEmulated;
 }
 
-// Checks if current system is an emulator that supports extensions.
-//  Sets (gSystemCapabilities & SUPPORTS_EMULATOR_EXTENSIONS)
-void check_emux_support(void) {
-    volatile u32 hasExtensions = 0;
-
-    // run `emux detect`
-    asm volatile(
-        "tne %0, %0"
-        : "=r" (hasExtensions) // Outputs
-        : "r" (hasExtensions) // Inputs
-        : // no clobbers
-    );
-
-    if (hasExtensions) {
-        gSystemCapabilities |= SUPPORTS_EMULATOR_EXTENSIONS;
-    }
-}
-
-// Some emulators will straight up crash if you run a trap instruction.
-//  Thus, we need to guard running `emux` detection behind valid systems.
-// Returns TRUE if an emulator won't crash trying to detect `emux` functionality.
-u32 emulator_supports_trap_instructions(u32 emulator) {
-    if (emulator & EMU_PROJECT64_1_OR_2) {
-        return FALSE;
-    }
-    if (emulator & EMU_WIIVC) {
-        return FALSE;
-    }
-
-    return TRUE;
-}
-
 // Tests various system quirks and initializes gEmulator to the detected emulator(s).
 //  Also initializes gSystemCapabilities.
 u32 detect_emulator() {

--- a/src/game/emutest.c
+++ b/src/game/emutest.c
@@ -74,6 +74,21 @@ static u8 check_cache_emulation() {
     return cacheEmulated;
 }
 
+static void check_emux_support(void) {
+    u64 hasExtensions = 0;
+
+    asm volatile(
+        "tne %0, %0"
+    : // no outputs
+    : "=r" (hasExtensions) // Inputs
+    : // no clobbers
+    );
+
+    if (hasExtensions) {
+        gSystemCapabilities |= SYSCAP_EMULATOR_EXTENSIONS;
+    }
+}
+
 u32 detect_emulator() {
     // Test to see if the libpl emulator extension is present.
     u32 magic;
@@ -91,6 +106,7 @@ u32 detect_emulator() {
 
     // If DPC registers are emulated, this is either console or a very accurate emulator
     if ((u32)IO_READ(DPC_PIPEBUSY_REG) | (u32)IO_READ(DPC_TMEM_REG) | (u32)IO_READ(DPC_BUFBUSY_REG)) {
+        check_emux_support();
         return EMU_CONSOLE;
     }
     
@@ -116,6 +132,7 @@ u32 detect_emulator() {
     // If cache is emulated, then this is likely Simple64, or some other accurate emulator.
     if (check_cache_emulation()) {
         gSystemCapabilities |= SYSCAP_CACHE;
+        check_emux_support();
         return EMU_OTHER;
     }
 
@@ -125,9 +142,11 @@ u32 detect_emulator() {
     // So in this case, it should result in 0x01040104
     osPiReadIo(0x1fd00104u, &magic);
     if (magic == 0u) {
+        check_emux_support();
         // Older versions of mupen (and pre-2.12 ParallelN64) just always read 0
         return EMU_MUPEN;
     } else if (magic != 0x01040104u) {
+        check_emux_support();
         // cen64 does... something. The result is consistent, but not what it should be
         return EMU_OTHER;
     }
@@ -143,6 +162,7 @@ u32 detect_emulator() {
         // requested the whole word, but that's actually wrong. Later versions of mupen
         // (and the Simple64 fork of it) get this wrong.
         case 0x0104:
+            check_emux_support();
             return EMU_MUPEN;
         // If reading a word gives the correct response, but reading a halfword always gives 0,
         // then we are dealing with some version of Project 64. Call into this helper function

--- a/src/game/emutest.c
+++ b/src/game/emutest.c
@@ -93,7 +93,7 @@ void check_emux_support(void) {
 }
 
 // Some emulators will straight up crash if you run a trap instruction.
-//  Make sure 
+//  Thus, we need to guard running `emux` detection behind valid systems.
 // Returns TRUE if an emulator won't crash trying to detect `emux` functionality.
 u32 emulator_supports_trap_instructions(u32 emulator) {
     if (gEmulator & EMU_PROJECT64_1_OR_2) {
@@ -149,7 +149,7 @@ u32 detect_emulator() {
 
     // If cache is emulated, then this is likely Simple64, or some other accurate emulator.
     if (check_cache_emulation()) {
-        gSystemCapabilities |= SUPPORTS_CACHE;
+        gSystemCapabilities |= SUPPORTS_CACHING;
         return EMU_OTHER;
     }
 

--- a/src/game/emutest.c
+++ b/src/game/emutest.c
@@ -74,7 +74,9 @@ static u8 check_cache_emulation() {
     return cacheEmulated;
 }
 
-static void check_emux_support(void) {
+// Checks if current system is an emulator that supports extensions.
+//  Sets (gSystemCapabilities & SUPPORTS_EMULATOR_EXTENSIONS)
+void check_emux_support(void) {
     volatile u32 hasExtensions = 0;
 
     // run `emux detect`
@@ -86,10 +88,26 @@ static void check_emux_support(void) {
     );
 
     if (hasExtensions) {
-        gSystemCapabilities |= SYSCAP_EMULATOR_EXTENSIONS;
+        gSystemCapabilities |= SUPPORTS_EMULATOR_EXTENSIONS;
     }
 }
 
+// Some emulators will straight up crash if you run a trap instruction.
+//  Make sure 
+// Returns TRUE if an emulator won't crash trying to detect `emux` functionality.
+u32 emulator_supports_trap_instructions(u32 emulator) {
+    if (gEmulator & EMU_PROJECT64_1_OR_2) {
+        return FALSE;
+    }
+    if (gEmulator & EMU_WIIVC) {
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+// Tests various system quirks and initializes gEmulator to the detected emulator(s).
+//  Also initializes gSystemCapabilities.
 u32 detect_emulator() {
     // Test to see if the libpl emulator extension is present.
     u32 magic;
@@ -99,7 +117,7 @@ u32 detect_emulator() {
         // libpl is supported. Must be ParallelN64
 #ifdef LIBPL
         if (libpl_is_supported(LPL_ABI_VERSION_CURRENT)) {
-            gSystemCapabilities |= SYSCAP_LIBPL;
+            gSystemCapabilities |= SUPPORTS_LIBPL;
         }
 #endif
         return EMU_PARALLEL_LAUNCHER;
@@ -107,7 +125,6 @@ u32 detect_emulator() {
 
     // If DPC registers are emulated, this is either console or a very accurate emulator
     if ((u32)IO_READ(DPC_PIPEBUSY_REG) | (u32)IO_READ(DPC_TMEM_REG) | (u32)IO_READ(DPC_BUFBUSY_REG)) {
-        check_emux_support();
         return EMU_CONSOLE;
     }
     
@@ -126,14 +143,13 @@ u32 detect_emulator() {
         fcr_set_rounding_mode(roundingMode);
         return EMU_WIIVC;
     } else {
-        gSystemCapabilities |= SYSCAP_FLOAT_ROUNDING_MODE;
+        gSystemCapabilities |= SUPPORTS_FLOAT_ROUNDING_MODE;
     }
     fcr_set_rounding_mode(roundingMode);
 
     // If cache is emulated, then this is likely Simple64, or some other accurate emulator.
     if (check_cache_emulation()) {
-        gSystemCapabilities |= SYSCAP_CACHE;
-        check_emux_support();
+        gSystemCapabilities |= SUPPORTS_CACHE;
         return EMU_OTHER;
     }
 
@@ -143,11 +159,9 @@ u32 detect_emulator() {
     // So in this case, it should result in 0x01040104
     osPiReadIo(0x1fd00104u, &magic);
     if (magic == 0u) {
-        check_emux_support();
         // Older versions of mupen (and pre-2.12 ParallelN64) just always read 0
         return EMU_MUPEN;
     } else if (magic != 0x01040104u) {
-        check_emux_support();
         // cen64 does... something. The result is consistent, but not what it should be
         return EMU_OTHER;
     }
@@ -163,7 +177,6 @@ u32 detect_emulator() {
         // requested the whole word, but that's actually wrong. Later versions of mupen
         // (and the Simple64 fork of it) get this wrong.
         case 0x0104:
-            check_emux_support();
             return EMU_MUPEN;
         // If reading a word gives the correct response, but reading a halfword always gives 0,
         // then we are dealing with some version of Project 64. Call into this helper function

--- a/src/game/emutest.c
+++ b/src/game/emutest.c
@@ -24,6 +24,7 @@ extern void __osPiRelAccess(void);
 
 u8 gEmulator = EMU_CONSOLE;
 u8 gSupportsLibpl = FALSE;
+u32 gSystemCapabilities = 0;
 
 static inline u32 get_pj64_version() {
     // When calling this function, we know that the emulator is some version of Project 64,
@@ -150,3 +151,15 @@ u32 detect_emulator() {
     // Note that Project64 4.0 will be detected here.
     return EMU_OTHER;
 } 
+
+void self_test_system_capabilities(void) {
+    if (check_cache_emulation()) {
+        gSystemCapabilities |= SYS_SUPPORTS_CACHE;
+    }
+#ifdef LIBPL
+    if (libpl_is_supported(LPL_ABI_VERSION_CURRENT)) {
+        gSystemCapabilities |= SYS_SUPPORTS_LIBPL;
+    }
+#endif // LIBPL
+
+}

--- a/src/game/emutest.h
+++ b/src/game/emutest.h
@@ -15,15 +15,15 @@ enum Emulator {
 };
 
 enum SystemCapabilities {
-    SYS_SUPPORTS_CACHE = (1 << 0),
-    SYS_SUPPORTS_FLOAT_ROUNDING_MODE = (1 << 1),
-    SYS_SUPPORTS_LIBPL = (1 << 2),
-    SYS_SUPPORTS_SOFTWARE_FRAMEBUFFER = (1 << 3),
-    SYS_SUPPORTS_EMUX = (1 << 4),
+    SYSCAP_CACHE = (1 << 0),
+    SYSCAP_FLOAT_ROUNDING_MODE = (1 << 1),
+    SYSCAP_LIBPL = (1 << 2),
+    SYSCAP_SOFTWARE_FRAMEBUFFER = (1 << 3),
+    SYSCAP_EMUX = (1 << 4),
 
     // idk how to implement the following lol
-    // SYS_SUPPORTS_DMA_TIMING = 0,
-    // SYS_SUPPORTS_RSP_PIPELINE_STALL_TIMING = 0,
+    // SYSCAP_DMA_TIMING = 0,
+    // SYSCAP_RSP_PIPELINE_STALL_TIMING = 0,
 };
 
 // initializes gEmulator
@@ -47,7 +47,7 @@ extern u32 detect_emulator();
 extern u8 gEmulator;
 
 // determines whether libpl is safe to use
-#define gSupportsLibpl (gSystemCapabilities & SYS_SUPPORTS_LIBPL)
+#define gSupportsLibpl (gSystemCapabilities & SYSCAP_LIBPL)
 
 /**
  * Bitflag that lists all system capabilities, for more granular

--- a/src/game/emutest.h
+++ b/src/game/emutest.h
@@ -44,7 +44,8 @@ extern u32 emulator_supports_trap_instructions(u32 emulator);
 
 extern void check_emux_support();
 
-/* gEmulator is an enum that identifies the current emulator.
+/**
+ * gEmulator is an enum that identifies the current emulator.
  * The enum values work as a bitfield, so you can use the & and | operators
  * to test for multiple emulators or versions at once.
  * 
@@ -67,8 +68,10 @@ extern u8 gEmulator;
  */
 extern u32 gSystemCapabilities;
 
-// Whether the emulator supports libpl.
-// Left for backwards compatibility
+/**
+ * Whether the emulator supports libpl.
+ *  Left in for backwards compatibility.
+ */
 #define gSupportsLibpl (gSystemCapabilities & SUPPORTS_LIBPL)
 
 // Included for backwards compatibility when upgrading from HackerSM64 2.0

--- a/src/game/emutest.h
+++ b/src/game/emutest.h
@@ -15,7 +15,7 @@ enum Emulator {
 };
 
 /**
- * Various detectable 
+ * Various detectable system capabilities
  */
 enum SystemCapabilities {
     // Whether the system caches instructions and data

--- a/src/game/emutest.h
+++ b/src/game/emutest.h
@@ -24,7 +24,7 @@ enum SystemCapabilities {
     // Whether the system supports changing how floats get rounded
     SUPPORTS_FLOAT_ROUNDING_MODE = (1 << 1),
 
-    // Whether the system can access libpl functionality
+    // Whether the system supports the `libpl` API on Parallel Launcher
     SUPPORTS_LIBPL = (1 << 2),
 
     // Whether the system can edit the framebuffer in software

--- a/src/game/emutest.h
+++ b/src/game/emutest.h
@@ -14,14 +14,26 @@ enum Emulator {
     EMU_OTHER                = (1 << 6), // Any other emulator
 };
 
+/**
+ * Various detectable 
+ */
 enum SystemCapabilities {
+    // Whether the system caches instructions and data
     SUPPORTS_CACHING = (1 << 0),
+
+    // Whether the system supports changing how floats get rounded
     SUPPORTS_FLOAT_ROUNDING_MODE = (1 << 1),
+
+    // Whether the system can access libpl functionality
     SUPPORTS_LIBPL = (1 << 2),
+
+    // Whether the system can edit the framebuffer in software
     SUPPORTS_SOFTWARE_FRAMEBUFFER = (1 << 3),
+
+    // Whether the system supports emulator-specific extensions through the `emux` API
     SUPPORTS_EMULATOR_EXTENSIONS = (1 << 4), // i.e. `emux`
 
-    // idk how to implement the following lol
+    // TODO: Figure out what these mean and implement them too
     // SUPPORTS_DMA_TIMING = 0,
     // SUPPORTS_RSP_PIPELINE_STALL_TIMING = 0,
 };

--- a/src/game/emutest.h
+++ b/src/game/emutest.h
@@ -19,7 +19,7 @@ enum SystemCapabilities {
     SYSCAP_FLOAT_ROUNDING_MODE = (1 << 1),
     SYSCAP_LIBPL = (1 << 2),
     SYSCAP_SOFTWARE_FRAMEBUFFER = (1 << 3),
-    SYSCAP_EMUX = (1 << 4),
+    SYSCAP_EMULATOR_EXTENSIONS = (1 << 4), // i.e. `emux`
 
     // idk how to implement the following lol
     // SYSCAP_DMA_TIMING = 0,

--- a/src/game/emutest.h
+++ b/src/game/emutest.h
@@ -47,7 +47,7 @@ extern u32 detect_emulator();
 extern u8 gEmulator;
 
 // determines whether libpl is safe to use
-extern u8 gSupportsLibpl;
+#define gSupportsLibpl (gSystemCapabilities & SYS_SUPPORTS_LIBPL)
 
 /**
  * Bitflag that lists all system capabilities, for more granular

--- a/src/game/emutest.h
+++ b/src/game/emutest.h
@@ -19,19 +19,19 @@ enum Emulator {
  */
 enum SystemCapabilities {
     // Whether the system caches instructions and data
-    SUPPORTS_CACHING = (1 << 0),
+    SUPPORTS_CACHING              = (1 << 0),
 
     // Whether the system supports changing how floats get rounded
-    SUPPORTS_FLOAT_ROUNDING_MODE = (1 << 1),
+    SUPPORTS_FLOAT_ROUNDING_MODE  = (1 << 1),
 
     // Whether the system supports the `libpl` API on Parallel Launcher
-    SUPPORTS_LIBPL = (1 << 2),
+    SUPPORTS_LIBPL                = (1 << 2),
 
     // Whether the system can edit the framebuffer in software
     SUPPORTS_SOFTWARE_FRAMEBUFFER = (1 << 3),
 
     // Whether the system supports emulator-specific extensions through the `emux` API
-    SUPPORTS_EMULATOR_EXTENSIONS = (1 << 4), // i.e. `emux`
+    SUPPORTS_EMULATOR_EXTENSIONS  = (1 << 4), // i.e. `emux`
 
     // TODO: Figure out what these mean and implement them too
     // SUPPORTS_DMA_TIMING = 0,

--- a/src/game/emutest.h
+++ b/src/game/emutest.h
@@ -18,10 +18,12 @@ enum SystemCapabilities {
     SYS_SUPPORTS_CACHE = (1 << 0),
     SYS_SUPPORTS_FLOAT_ROUNDING_MODE = (1 << 1),
     SYS_SUPPORTS_LIBPL = (1 << 2),
-    SYS_SUPPORTS_DMA_TIMING = (1 << 3),
-    SYS_SUPPORTS_RSP_PIPELINE_STALL_TIMING = (1 << 4),
-    SYS_SUPPORTS_SOFTWARE_FRAMEBUFFER = (1 << 5),
-    SYS_SUPPORTS_EMUX = (1 << 6),
+    SYS_SUPPORTS_SOFTWARE_FRAMEBUFFER = (1 << 3),
+    SYS_SUPPORTS_EMUX = (1 << 4),
+
+    // idk how to implement the following lol
+    // SYS_SUPPORTS_DMA_TIMING = 0,
+    // SYS_SUPPORTS_RSP_PIPELINE_STALL_TIMING = 0,
 };
 
 // initializes gEmulator

--- a/src/game/emutest.h
+++ b/src/game/emutest.h
@@ -30,7 +30,9 @@ enum SystemCapabilities {
     // Whether the system can edit the framebuffer in software
     SUPPORTS_SOFTWARE_FRAMEBUFFER = (1 << 3),
 
-    // Whether the system supports emulator-specific extensions through the `emux` API
+    // Whether the system supports emulator-specific extensions through the `emux` API.
+    //  (Nothing in HackerSM64 currently uses this, but it's here due to
+    //   being easy to detect)
     SUPPORTS_EMULATOR_EXTENSIONS  = (1 << 4), // i.e. `emux`
 
     // TODO: Figure out what these mean and implement them too

--- a/src/game/emutest.h
+++ b/src/game/emutest.h
@@ -15,7 +15,7 @@ enum Emulator {
 };
 
 enum SystemCapabilities {
-    SUPPORTS_CACHE = (1 << 0),
+    SUPPORTS_CACHING = (1 << 0),
     SUPPORTS_FLOAT_ROUNDING_MODE = (1 << 1),
     SUPPORTS_LIBPL = (1 << 2),
     SUPPORTS_SOFTWARE_FRAMEBUFFER = (1 << 3),

--- a/src/game/emutest.h
+++ b/src/game/emutest.h
@@ -14,6 +14,16 @@ enum Emulator {
     EMU_OTHER                = (1 << 6), // Any other emulator
 };
 
+enum SystemCapabilities {
+    SYS_SUPPORTS_CACHE = (1 << 0),
+    SYS_SUPPORTS_FLOAT_ROUNDING_MODE = (1 << 1),
+    SYS_SUPPORTS_LIBPL = (1 << 2),
+    SYS_SUPPORTS_DMA_TIMING = (1 << 3),
+    SYS_SUPPORTS_RSP_PIPELINE_STALL_TIMING = (1 << 4),
+    SYS_SUPPORTS_SOFTWARE_FRAMEBUFFER = (1 << 5),
+    SYS_SUPPORTS_EMUX = (1 << 6),
+};
+
 // initializes gEmulator
 extern u32 detect_emulator();
 
@@ -36,6 +46,12 @@ extern u8 gEmulator;
 
 // determines whether libpl is safe to use
 extern u8 gSupportsLibpl;
+
+/**
+ * Bitflag that lists all system capabilities, for more granular
+ * feature detection than gEmulator.
+ */
+extern u32 gSystemCapabilities;
 
 // Included for backwards compatibility when upgrading from HackerSM64 2.0
 #define gIsConsole ((gEmulator & EMU_CONSOLE) != 0)

--- a/src/game/emutest.h
+++ b/src/game/emutest.h
@@ -49,14 +49,15 @@ extern u32 check_emux_support();
  */
 extern u8 gEmulator;
 
-// determines whether libpl is safe to use
-#define gSupportsLibpl (gSystemCapabilities & SUPPORTS_LIBPL)
-
 /**
  * Bitflag that lists all system capabilities, for more granular
  * feature detection than gEmulator.
  */
 extern u32 gSystemCapabilities;
+
+// Whether the emulator supports libpl.
+// Left for backwards compatibility
+#define gSupportsLibpl (gSystemCapabilities & SUPPORTS_LIBPL)
 
 // Included for backwards compatibility when upgrading from HackerSM64 2.0
 #define gIsConsole ((gEmulator & EMU_CONSOLE) != 0)

--- a/src/game/emutest.h
+++ b/src/game/emutest.h
@@ -30,10 +30,8 @@ enum SystemCapabilities {
     // Whether the system can edit the framebuffer in software
     SUPPORTS_SOFTWARE_FRAMEBUFFER = (1 << 3),
 
-    // Whether the system supports emulator-specific extensions through the `emux` API.
-    //  (Nothing in HackerSM64 currently uses this, but it's here due to
-    //   being easy to detect)
-    SUPPORTS_EMULATOR_EXTENSIONS  = (1 << 4), // i.e. `emux`
+    // TODO: `emux` is a developing standard.
+    // SUPPORTS_EMULATOR_EXTENSIONS  = (1 << 4), // i.e. `emux`
 
     // TODO: Figure out what these mean and implement them too
     // SUPPORTS_DMA_TIMING = 0,
@@ -41,10 +39,6 @@ enum SystemCapabilities {
 };
 
 extern u32 detect_emulator();
-
-extern u32 emulator_supports_trap_instructions(u32 emulator);
-
-extern void check_emux_support();
 
 /**
  * gEmulator is an enum that identifies the current emulator.

--- a/src/game/emutest.h
+++ b/src/game/emutest.h
@@ -15,19 +15,22 @@ enum Emulator {
 };
 
 enum SystemCapabilities {
-    SYSCAP_CACHE = (1 << 0),
-    SYSCAP_FLOAT_ROUNDING_MODE = (1 << 1),
-    SYSCAP_LIBPL = (1 << 2),
-    SYSCAP_SOFTWARE_FRAMEBUFFER = (1 << 3),
-    SYSCAP_EMULATOR_EXTENSIONS = (1 << 4), // i.e. `emux`
+    SUPPORTS_CACHE = (1 << 0),
+    SUPPORTS_FLOAT_ROUNDING_MODE = (1 << 1),
+    SUPPORTS_LIBPL = (1 << 2),
+    SUPPORTS_SOFTWARE_FRAMEBUFFER = (1 << 3),
+    SUPPORTS_EMULATOR_EXTENSIONS = (1 << 4), // i.e. `emux`
 
     // idk how to implement the following lol
-    // SYSCAP_DMA_TIMING = 0,
-    // SYSCAP_RSP_PIPELINE_STALL_TIMING = 0,
+    // SUPPORTS_DMA_TIMING = 0,
+    // SUPPORTS_RSP_PIPELINE_STALL_TIMING = 0,
 };
 
-// initializes gEmulator
 extern u32 detect_emulator();
+
+extern u32 emulator_supports_trap_instructions(u32 emulator);
+
+extern u32 check_emux_support();
 
 /* gEmulator is an enum that identifies the current emulator.
  * The enum values work as a bitfield, so you can use the & and | operators
@@ -47,7 +50,7 @@ extern u32 detect_emulator();
 extern u8 gEmulator;
 
 // determines whether libpl is safe to use
-#define gSupportsLibpl (gSystemCapabilities & SYSCAP_LIBPL)
+#define gSupportsLibpl (gSystemCapabilities & SUPPORTS_LIBPL)
 
 /**
  * Bitflag that lists all system capabilities, for more granular

--- a/src/game/emutest.h
+++ b/src/game/emutest.h
@@ -42,7 +42,7 @@ extern u32 detect_emulator();
 
 extern u32 emulator_supports_trap_instructions(u32 emulator);
 
-extern u32 check_emux_support();
+extern void check_emux_support();
 
 /* gEmulator is an enum that identifies the current emulator.
  * The enum values work as a bitfield, so you can use the & and | operators

--- a/src/game/game_init.c
+++ b/src/game/game_init.c
@@ -425,10 +425,9 @@ static void check_fbe(s32 frameIndex) {
         // Write pixel to the framebuffer
         gFramebuffers[sRenderingFramebuffer][fbePixelOffset] = fbePixelVal;
     } else {
-        // Check if pixel persisted in the framebuffer after executing the display list that clears it (but before updating sRenderingFramebuffer!)
-        if (gFramebuffers[sRenderingFramebuffer][fbePixelOffset] == fbePixelVal) {
-            gSystemCapabilities &= ~SUPPORTS_SOFTWARE_FRAMEBUFFER;
-        } else {
+        // Check if pixel persisted in the framebuffer after executing the display list
+        //  that clears it (but before updating sRenderingFramebuffer!)
+        if (gFramebuffers[sRenderingFramebuffer][fbePixelOffset] != fbePixelVal) {
             gSystemCapabilities |= SUPPORTS_SOFTWARE_FRAMEBUFFER;
         }
     }
@@ -450,15 +449,15 @@ void render_init(void) {
     clear_framebuffer(0);
     end_master_display_list();
 
-    // Skip the FBE check if system is already determined to be console/Ares
-    if (!(gSystemCapabilities & SUPPORTS_SOFTWARE_FRAMEBUFFER)) {
+    // Skip the FBE check if system is console,
+    //  or had already been determined to support framebuffer emulation.
+    if (gSystemCapabilities & SUPPORTS_SOFTWARE_FRAMEBUFFER) {
+        exec_display_list(&gGfxPool->spTask);
+    } else {
         check_fbe(0);
-    }
 
-    exec_display_list(&gGfxPool->spTask);
+        exec_display_list(&gGfxPool->spTask);
 
-    // Skip the FBE check if system is already determined to be console/Ares
-    if (!(gSystemCapabilities & SUPPORTS_SOFTWARE_FRAMEBUFFER)) {
         // Wait for frame rendering to complete to prevent race condition with FBE check
         osRecvMesg(&gGfxVblankQueue, &gMainReceivedMesg, OS_MESG_BLOCK);
         check_fbe(1);

--- a/src/game/game_init.c
+++ b/src/game/game_init.c
@@ -409,6 +409,34 @@ void draw_reset_bars(void) {
 }
 
 /**
+ * Check if we are emulating the framebuffer
+ * 
+ * s32 frameIndex:
+ *  0: Write to the framebuffer, wait to process displaylist
+ *  1: Check whether the framebuffer write persisted
+ */
+static void check_fbe(s32 frameIndex) {
+    // NOTE: For whatever reason, checking against pixel index 12 fails on some versions of GlideN64 (pain).
+    // So apparently, this value being set to 13 actually matters...???
+    const s32 fbePixelOffset = 13;
+    const u16 fbePixelVal = 0xFF01;
+
+    if (!(gSystemCapabilities & SUPPORTS_SOFTWARE_FRAMEBUFFER)) {
+        if (frameIndex == 0) {
+            // Write pixel to the framebuffer
+            gFramebuffers[sRenderingFramebuffer][fbePixelOffset] = fbePixelVal;
+        } else {
+            // Check if pixel persisted in the framebuffer after executing the display list that clears it (but before updating sRenderingFramebuffer!)
+            if (gFramebuffers[sRenderingFramebuffer][fbePixelOffset] == fbePixelVal) {
+                gSystemCapabilities &= ~SUPPORTS_SOFTWARE_FRAMEBUFFER;
+            } else {
+                gSystemCapabilities |= SUPPORTS_SOFTWARE_FRAMEBUFFER;
+            }
+        }
+    }
+}
+
+/**
  * Initial settings for the first rendered frame.
  */
 void render_init(void) {
@@ -423,7 +451,15 @@ void render_init(void) {
     init_rcp(CLEAR_ZBUFFER);
     clear_framebuffer(0);
     end_master_display_list();
+    check_fbe(0);
     exec_display_list(&gGfxPool->spTask);
+
+    // Wait for frame rendering to complete to prevent race condition with FBE check
+    osRecvMesg(&gGfxVblankQueue, &gMainReceivedMesg, OS_MESG_BLOCK);
+    check_fbe(1);
+
+    // Send message back to queue to prevent locking up
+    osSendMesg(&gGfxVblankQueue, gMainReceivedMesg, OS_MESG_BLOCK);
 
     // Skip incrementing the initial framebuffer index on certain emulators so that they display immediately as the Gfx task finishes
     // This will break accurate emulators, so only enable on Project64, Parallel Launcher and Mupen.

--- a/src/game/game_init.c
+++ b/src/game/game_init.c
@@ -449,15 +449,23 @@ void render_init(void) {
     init_rcp(CLEAR_ZBUFFER);
     clear_framebuffer(0);
     end_master_display_list();
-    check_fbe(0);
+
+    // Skip the FBE check if system is already determined to be console/Ares
+    if (!(gSystemCapabilities & SUPPORTS_SOFTWARE_FRAMEBUFFER)) {
+        check_fbe(0);
+    }
+
     exec_display_list(&gGfxPool->spTask);
 
-    // Wait for frame rendering to complete to prevent race condition with FBE check
-    osRecvMesg(&gGfxVblankQueue, &gMainReceivedMesg, OS_MESG_BLOCK);
-    check_fbe(1);
+    // Skip the FBE check if system is already determined to be console/Ares
+    if (!(gSystemCapabilities & SUPPORTS_SOFTWARE_FRAMEBUFFER)) {
+        // Wait for frame rendering to complete to prevent race condition with FBE check
+        osRecvMesg(&gGfxVblankQueue, &gMainReceivedMesg, OS_MESG_BLOCK);
+        check_fbe(1);
 
-    // Send message back to queue to prevent locking up
-    osSendMesg(&gGfxVblankQueue, gMainReceivedMesg, OS_MESG_BLOCK);
+        // Send message back to queue to prevent locking up
+        osSendMesg(&gGfxVblankQueue, gMainReceivedMesg, OS_MESG_BLOCK);
+    }
 
     // Skip incrementing the initial framebuffer index on certain emulators so that they display immediately as the Gfx task finishes
     // This will break accurate emulators, so only enable on Project64, Parallel Launcher and Mupen.

--- a/src/game/game_init.c
+++ b/src/game/game_init.c
@@ -421,17 +421,15 @@ static void check_fbe(s32 frameIndex) {
     const s32 fbePixelOffset = 13;
     const u16 fbePixelVal = 0xFF01;
 
-    if (!(gSystemCapabilities & SUPPORTS_SOFTWARE_FRAMEBUFFER)) {
-        if (frameIndex == 0) {
-            // Write pixel to the framebuffer
-            gFramebuffers[sRenderingFramebuffer][fbePixelOffset] = fbePixelVal;
+    if (frameIndex == 0) {
+        // Write pixel to the framebuffer
+        gFramebuffers[sRenderingFramebuffer][fbePixelOffset] = fbePixelVal;
+    } else {
+        // Check if pixel persisted in the framebuffer after executing the display list that clears it (but before updating sRenderingFramebuffer!)
+        if (gFramebuffers[sRenderingFramebuffer][fbePixelOffset] == fbePixelVal) {
+            gSystemCapabilities &= ~SUPPORTS_SOFTWARE_FRAMEBUFFER;
         } else {
-            // Check if pixel persisted in the framebuffer after executing the display list that clears it (but before updating sRenderingFramebuffer!)
-            if (gFramebuffers[sRenderingFramebuffer][fbePixelOffset] == fbePixelVal) {
-                gSystemCapabilities &= ~SUPPORTS_SOFTWARE_FRAMEBUFFER;
-            } else {
-                gSystemCapabilities |= SUPPORTS_SOFTWARE_FRAMEBUFFER;
-            }
+            gSystemCapabilities |= SUPPORTS_SOFTWARE_FRAMEBUFFER;
         }
     }
 }


### PR DESCRIPTION
Addresses #652 
for 2.4 both systems will coexist

Need clarification on the following checks (especially whether they're useful for any game devs):
- DMA timings
- RSP pipeline stall timings
- Certain 64-bit mode behaviors