### PR TITLE
Debug fly improvements

### DIFF
--- a/src/game/camera.c
+++ b/src/game/camera.c
@@ -1116,10 +1116,6 @@ s32 snap_to_45_degrees(s16 angle) {
     return angle;
 }
 
-#ifdef PUPPYPRINT_DEBUG
-extern u8 sDebugMenu;
-#endif
-
 /**
  * A mode that only has 8 camera angles, 45 degrees apart
  */

--- a/src/game/camera.c
+++ b/src/game/camera.c
@@ -1116,6 +1116,10 @@ s32 snap_to_45_degrees(s16 angle) {
     return angle;
 }
 
+#ifdef PUPPYPRINT_DEBUG
+extern u8 sDebugMenu;
+#endif
+
 /**
  * A mode that only has 8 camera angles, 45 degrees apart
  */
@@ -1135,20 +1139,31 @@ void mode_8_directions_camera(struct Camera *c) {
     }
 #ifdef PARALLEL_LAKITU_CAM
     // extra functionality
-    else if (gPlayer1Controller->buttonPressed & U_JPAD) {
-        s8DirModeYawOffset = 0;
-        s8DirModeYawOffset = gMarioState->faceAngle[1] - 0x8000;
+#ifdef PUPPYPRINT_DEBUG
+    if (!sDebugMenu) {
+#endif // PUPPYPRINT_DEBUG    
+#ifndef ENABLE_DEBUG_FREE_MOVE
+        if (gPlayer1Controller->buttonPressed & U_JPAD) {
+            s8DirModeYawOffset = 0;
+            s8DirModeYawOffset = gMarioState->faceAngle[1] - 0x8000;
+        } else if (gPlayer1Controller->buttonPressed & D_JPAD) {
+#else
+        if ((gPlayer1Controller->buttonPressed & D_JPAD) && (gMarioState->action != ACT_DEBUG_FREE_MOVE)) {
+#endif // ENABLE_DEBUG_FREE_MOVE
+            s8DirModeYawOffset = snap_to_45_degrees(s8DirModeYawOffset);
+        }
+
+        if (gPlayer1Controller->buttonDown & L_JPAD) {
+            s8DirModeYawOffset -= DEGREES(2);
+        } 
+        if (gPlayer1Controller->buttonDown & R_JPAD) {
+            s8DirModeYawOffset += DEGREES(2);
+        }
+        
+#ifdef PUPPYPRINT_DEBUG
     }
-    else if (gPlayer1Controller->buttonDown & L_JPAD) {
-        s8DirModeYawOffset -= DEGREES(2);
-    }
-    else if (gPlayer1Controller->buttonDown & R_JPAD) {
-        s8DirModeYawOffset += DEGREES(2);
-    }
-    else if (gPlayer1Controller->buttonPressed & D_JPAD) {
-        s8DirModeYawOffset = snap_to_45_degrees(s8DirModeYawOffset);
-    }
-#endif
+#endif // PUPPYPRINT_DEBUG
+#endif // PARALLEL_LAKITU_CAM
 
     lakitu_zoom(400.f, 0x900);
     c->nextYaw = update_8_directions_camera(c, c->focus, pos);

--- a/src/game/camera.c
+++ b/src/game/camera.c
@@ -1152,14 +1152,12 @@ void mode_8_directions_camera(struct Camera *c) {
 #endif // ENABLE_DEBUG_FREE_MOVE
             s8DirModeYawOffset = snap_to_45_degrees(s8DirModeYawOffset);
         }
-
         if (gPlayer1Controller->buttonDown & L_JPAD) {
             s8DirModeYawOffset -= DEGREES(2);
         } 
         if (gPlayer1Controller->buttonDown & R_JPAD) {
             s8DirModeYawOffset += DEGREES(2);
         }
-        
 #ifdef PUPPYPRINT_DEBUG
     }
 #endif // PUPPYPRINT_DEBUG

--- a/src/game/mario.c
+++ b/src/game/mario.c
@@ -29,6 +29,7 @@
 #include "object_helpers.h"
 #include "object_list_processor.h"
 #include "print.h"
+#include "puppyprint.h"
 #include "save_file.h"
 #include "sound_init.h"
 #include "rumble_init.h"
@@ -1697,10 +1698,6 @@ void queue_rumble_particles(struct MarioState *m) {
         reset_rumble_timers_slip();
     }
 }
-#endif
-
-#ifdef PUPPYPRINT_DEBUG
-extern u8 sDebugMenu;
 #endif
 
 /**

--- a/src/game/mario.c
+++ b/src/game/mario.c
@@ -1699,6 +1699,10 @@ void queue_rumble_particles(struct MarioState *m) {
 }
 #endif
 
+#ifdef PUPPYPRINT_DEBUG
+extern u8 sDebugMenu;
+#endif
+
 /**
  * Main function for executing Mario's behavior. Returns particleFlags.
  */
@@ -1713,13 +1717,19 @@ s32 execute_mario_action(UNUSED struct Object *obj) {
     if (gMarioState->action) {
 #ifdef ENABLE_DEBUG_FREE_MOVE
         if (
+#ifdef PUPPYPRINT_DEBUG
+            !sDebugMenu &&
+#endif // PUPPYPRINT_DEBUG
+            (gMarioState->action != ACT_DEBUG_FREE_MOVE) &&
             (gMarioState->controller->buttonDown & U_JPAD) &&
             !(gMarioState->controller->buttonDown & L_TRIG)
         ) {
-            set_camera_mode(gMarioState->area->camera, CAMERA_MODE_8_DIRECTIONS, 1);
+            if (gMarioState->area->camera->mode != CAMERA_MODE_8_DIRECTIONS) {
+                set_camera_mode(gMarioState->area->camera, CAMERA_MODE_8_DIRECTIONS, 1);
+            }
             set_mario_action(gMarioState, ACT_DEBUG_FREE_MOVE, 0);
         }
-#endif
+#endif // ENABLE_DEBUG_FREE_MOVE
 #ifdef ENABLE_CREDITS_BENCHMARK
         static s32 startedBenchmark = FALSE;
         if (!startedBenchmark) {

--- a/src/game/mario_actions_cutscene.c
+++ b/src/game/mario_actions_cutscene.c
@@ -513,6 +513,10 @@ s32 act_reading_sign(struct MarioState *m) {
     return FALSE;
 }
 
+#ifdef PUPPYPRINT_DEBUG
+extern u8 sDebugMenu;
+#endif
+
 s32 act_debug_free_move(struct MarioState *m) {
     struct WallCollisionData wallData;
     struct Surface *floor, *ceil;
@@ -528,18 +532,32 @@ s32 act_debug_free_move(struct MarioState *m) {
 
     set_mario_animation(m, MARIO_ANIM_A_POSE);
     vec3f_copy(pos, m->pos);
+#ifdef USE_PROFILER
+    if (
+        !(gPlayer1Controller->buttonDown & L_TRIG)
+#ifdef PUPPYPRINT_DEBUG
+        && !sDebugMenu
+#endif // PUPPYPRINT_DEBUG
+    ) {
+#endif // USE_PROFILER
+        if (gPlayer1Controller->buttonDown & U_JPAD) {
+            pos[1] += 16.0f * speed;
+        }
+        if (gPlayer1Controller->buttonDown & D_JPAD) {
+            pos[1] -= 16.0f * speed;
+        }
+#ifdef USE_PROFILER
+    }
+#endif
 
-    if (gPlayer1Controller->buttonDown & U_JPAD) {
-        pos[1] += 16.0f * speed;
-    }
-    if (gPlayer1Controller->buttonDown & D_JPAD) {
-        pos[1] -= 16.0f * speed;
-    }
     if (gPlayer1Controller->buttonPressed & A_BUTTON) {
         vec3_zero(m->vel);
         m->forwardVel = 0.0f;
-
-        set_camera_mode(m->area->camera, m->area->camera->defMode, 1);
+        
+        if (m->area->camera->mode != m->area->camera->defMode) {
+            set_camera_mode(m->area->camera, m->area->camera->defMode, 1);
+        }
+        
         m->input &= ~INPUT_A_PRESSED;
         if (m->pos[1] <= (m->waterLevel - 100)) {
             return set_mario_action(m, ACT_WATER_IDLE, 0);

--- a/src/game/mario_actions_cutscene.c
+++ b/src/game/mario_actions_cutscene.c
@@ -532,6 +532,7 @@ s32 act_debug_free_move(struct MarioState *m) {
 
     set_mario_animation(m, MARIO_ANIM_A_POSE);
     vec3f_copy(pos, m->pos);
+
 #ifdef USE_PROFILER
     if (
         !(gPlayer1Controller->buttonDown & L_TRIG)

--- a/src/game/mario_actions_cutscene.c
+++ b/src/game/mario_actions_cutscene.c
@@ -23,6 +23,7 @@
 #include "moving_texture.h"
 #include "object_helpers.h"
 #include "object_list_processor.h"
+#include "puppyprint.h"
 #include "save_file.h"
 #include "seq_ids.h"
 #include "sound_init.h"
@@ -512,10 +513,6 @@ s32 act_reading_sign(struct MarioState *m) {
     vec3s_set(marioObj->header.gfx.angle, 0x0, m->faceAngle[1], 0x0);
     return FALSE;
 }
-
-#ifdef PUPPYPRINT_DEBUG
-extern u8 sDebugMenu;
-#endif
 
 s32 act_debug_free_move(struct MarioState *m) {
     struct WallCollisionData wallData;

--- a/src/game/puppyprint.h
+++ b/src/game/puppyprint.h
@@ -119,6 +119,7 @@ enum PuppyFont {
     FONT_NUM
 };
 
+extern u8 sDebugMenu;
 extern u8 sPPDebugPage;
 extern u8 gPuppyFont;
 extern ColorRGBA gCurrEnvCol;

--- a/src/game/puppyprint.h
+++ b/src/game/puppyprint.h
@@ -119,8 +119,10 @@ enum PuppyFont {
     FONT_NUM
 };
 
+#ifdef PUPPYPRINT_DEBUG
 extern u8 sDebugMenu;
 extern u8 sPPDebugPage;
+#endif
 extern u8 gPuppyFont;
 extern ColorRGBA gCurrEnvCol;
 extern s32 ramsizeSegment[33];


### PR DESCRIPTION
Removes some of the jank around debug fly and its interactions with other uses of the D-Pad:
- Prevents D-Pad Up/Down ascending/descending in debug fly when activating the profiler or scrolling between Puppyprint debug pages
- Prevents D-Pad Up/Down activating parallel lakitu camera's features when debug fly is enabled/active respectively
- Prevents debug fly being activated when scrolling between Puppyprint debug pages
- Prevents camera mode being reset when entering/exiting debug fly if the camera is already in the correct mode

Button checks for parallel lakitu camera were adjusted for the sake of cleaner code here, so the D-Pad buttons aren't mutually exclusive anymore, but I think it makes more sense that way anyway (e.g. holding D-Pad Left and Right at the same time no long pans the camera).