### PR TITLE
Fix puppyprint ram size reporting

### DIFF
--- a/src/game/puppyprint.h
+++ b/src/game/puppyprint.h
@@ -122,12 +122,10 @@ enum PuppyFont {
 extern u8 sPPDebugPage;
 extern u8 gPuppyFont;
 extern ColorRGBA gCurrEnvCol;
-extern s32 ramsizeSegment[33];
 extern const s8 nameTable;
 extern s32 mempool;
 extern f32 textSize;
 extern u32 gPoolMem;
-extern u32 gMiscMem;
 extern u8 gPuppyWarp;
 extern u8 gPuppyWarpArea;
 extern u8 gLastWarpID;


### PR DESCRIPTION
Fixes a crash on 3.0 that was introduced by segment reallocations and some hardcoding on Puppyprint's end. Also reworks the ram size reporting to make slightly more sense.