### PR TITLE
Remove vanilla camera triggers when `ENABLE_VANILLA_CAM_PROCESSING` isn't defined

### DIFF
--- a/src/game/camera.c
+++ b/src/game/camera.c
@@ -5842,9 +5842,11 @@ void surface_type_modes_thi(struct Camera *c) {
  * exit. Using hyperspeed, the earlier area can be directly exited from, keeping the changes it applies.
  */
 struct CameraTrigger sCamSL[] = {
+#ifdef ENABLE_VANILLA_CAM_PROCESSING
     { 1, cam_sl_snowman_head_8dir, 1119, 3584, 1125, 1177, 358, 358, -0x1D27 },
     // This trigger surrounds the previous one
     { 1, cam_sl_free_roam, 1119, 3584, 1125, 4096, 4096, 4096, -0x1D27 },
+#endif // ENABLE_VANILLA_CAM_PROCESSING
     NULL_TRIGGER
 };
 
@@ -5854,8 +5856,10 @@ struct CameraTrigger sCamSL[] = {
  * tunnel. Both sides achieve their effect by editing the camera yaw.
  */
 struct CameraTrigger sCamTHI[] = {
+#ifdef ENABLE_VANILLA_CAM_PROCESSING
     { 1, cam_thi_move_cam_through_tunnel, -4609, -2969, 6448, 100, 300, 300, 0 },
     { 1, cam_thi_look_through_tunnel,     -4809, -2969, 6448, 100, 300, 300, 0 },
+#endif // ENABLE_VANILLA_CAM_PROCESSING
     NULL_TRIGGER
 };
 
@@ -5864,12 +5868,14 @@ struct CameraTrigger sCamTHI[] = {
  * start the cutscene for entering the CotMC pool.
  */
 struct CameraTrigger sCamHMC[] = {
+#ifdef ENABLE_VANILLA_CAM_PROCESSING
     { 1, cam_hmc_enter_maze, 1996, 102, 0, 205, 100, 205, 0 },
     { 1, cam_castle_hmc_start_pool_cutscene, 3350, -4689, 4800, 600, 50, 600, 0 },
     { 1, cam_hmc_elevator_black_hole, -3278, 1236, 1379, 358, 200, 358, 0 },
     { 1, cam_hmc_elevator_maze_emergency_exit, -2816, 2055, -2560, 358, 200, 358, 0 },
     { 1, cam_hmc_elevator_lake, -3532, 1543, -7040, 358, 200, 358, 0 },
     { 1, cam_hmc_elevator_maze, -972, 1543, -7347, 358, 200, 358, 0 },
+#endif // ENABLE_VANILLA_CAM_PROCESSING
     NULL_TRIGGER
 };
 
@@ -5879,10 +5885,12 @@ struct CameraTrigger sCamHMC[] = {
  * radial.
  */
 struct CameraTrigger sCamSSL[] = {
+#ifdef ENABLE_VANILLA_CAM_PROCESSING
     { 1, cam_ssl_enter_pyramid_top, -2048, 1080, -1024, 150, 150, 150, 0 },
     { 2, cam_ssl_pyramid_center, 0, -104, -104, 1248, 1536, 2950, 0 },
     { 2, cam_ssl_pyramid_center, 0, 2500, 256, 515, 5000, 515, 0 },
     { 3, cam_ssl_boss_room, 0, -1534, -2040, 1000, 800, 1000, 0 },
+#endif // ENABLE_VANILLA_CAM_PROCESSING
     NULL_TRIGGER
 };
 
@@ -5891,12 +5899,14 @@ struct CameraTrigger sCamSSL[] = {
  * the end of the ride.
  */
 struct CameraTrigger sCamRR[] = {
+#ifdef ENABLE_VANILLA_CAM_PROCESSING
     { 1, cam_rr_exit_building_side, -4197, 3819, -3087, 1769, 1490, 342, 0 },
     { 1, cam_rr_enter_building_side, -4197, 3819, -3771, 769, 490, 342, 0 },
     { 1, cam_rr_enter_building_window, -5603, 4834, -5209, 300, 600, 591, 0 },
     { 1, cam_rr_enter_building, -2609, 3730, -5463, 300, 650, 577, 0 },
     { 1, cam_rr_exit_building_top, -4196, 7343, -5155, 4500, 1000, 4500, 0 },
     { 1, cam_rr_enter_building, -4196, 6043, -5155, 500, 300, 500, 0 },
+#endif // ENABLE_VANILLA_CAM_PROCESSING
     NULL_TRIGGER,
 };
 
@@ -5908,8 +5918,10 @@ struct CameraTrigger sCamRR[] = {
  * to free_roam when Mario is not walking up the tower.
  */
 struct CameraTrigger sCamBOB[] = {
+#ifdef ENABLE_VANILLA_CAM_PROCESSING
     {  1, cam_bob_tower, 2468, 2720, -4608, 3263, 1696, 3072, 0 },
     { -1, cam_bob_default_free_roam, 0, 0, 0, 0, 0, 0, 0 },
+#endif // ENABLE_VANILLA_CAM_PROCESSING
     NULL_TRIGGER
 };
 
@@ -5917,7 +5929,9 @@ struct CameraTrigger sCamBOB[] = {
  * The CotMC trigger is only used to prevent fix Lakitu in place when Mario exits through the waterfall.
  */
 struct CameraTrigger sCamCotMC[] = {
+#ifdef ENABLE_VANILLA_CAM_PROCESSING
     { 1, cam_cotmc_exit_waterfall, 0, 1500, 3500, 550, 10000, 1500, 0 },
+#endif // ENABLE_VANILLA_CAM_PROCESSING
     NULL_TRIGGER
 };
 
@@ -5925,8 +5939,10 @@ struct CameraTrigger sCamCotMC[] = {
  * The CCM triggers are used to set the flag that says when Mario is in the slide shortcut.
  */
 struct CameraTrigger sCamCCM[] = {
+#ifdef ENABLE_VANILLA_CAM_PROCESSING
     { 2, cam_ccm_enter_slide_shortcut, -4846, 2061, 27, 1229, 1342, 396, 0 },
     { 2, cam_ccm_leave_slide_shortcut, -6412, -3917, -6246, 307, 185, 132, 0 },
+#endif // ENABLE_VANILLA_CAM_PROCESSING
     NULL_TRIGGER
 };
 
@@ -5938,6 +5954,7 @@ struct CameraTrigger sCamCCM[] = {
  * and one trigger that starts the enter pool cutscene when Mario enters HMC.
  */
 struct CameraTrigger sCamCastle[] = {
+#ifdef ENABLE_VANILLA_CAM_PROCESSING
     { 1, cam_castle_close_mode, -1100, 657, -1346, 300, 150, 300, 0 },
     { 1, cam_castle_enter_lobby, -1099, 657, -803, 300, 150, 300, 0 },
     { 1, cam_castle_close_mode, -2304, -264, -4072, 140, 150, 140, 0 },
@@ -5974,6 +5991,7 @@ struct CameraTrigger sCamCastle[] = {
     { 1, cam_castle_basement_look_downstairs, -1027, -587, -718, 318, 486, 577, 0 },
     { 1, cam_castle_lobby_entrance, -1023, 376, 1830, 300, 400, 300, 0 },
     { 3, cam_castle_hmc_start_pool_cutscene, 2485, -1689, -2659, 600, 50, 600, 0 },
+#endif // ENABLE_VANILLA_CAM_PROCESSING
     NULL_TRIGGER
 };
 
@@ -5984,6 +6002,7 @@ struct CameraTrigger sCamCastle[] = {
  * The triggers are also responsible for warping the camera below platforms.
  */
 struct CameraTrigger sCamBBH[] = {
+#ifdef ENABLE_VANILLA_CAM_PROCESSING
     { 1, cam_bbh_enter_front_door, 742, 0, 2369, 200, 200, 200, 0 },
     { 1, cam_bbh_leave_front_door, 741, 0, 1827, 200, 200, 200, 0 },
     { 1, cam_bbh_room_1, 222, 0, 1458, 200, 200, 200, 0 },
@@ -6044,6 +6063,7 @@ struct CameraTrigger sCamBBH[] = {
     { 1, cam_bbh_room_12_upper, -2939, -205, 5367, 300, 100, 300, 0 },
     { 1, cam_bbh_room_12_upper, -2332, -204, 4714, 250, 200, 250, 0x6000 },
     { 1, cam_bbh_room_0_back_entrance, -1939, -204, 4340, 250, 200, 250, 0x6000 },
+#endif // ENABLE_VANILLA_CAM_PROCESSING
     NULL_TRIGGER
 };
 


### PR DESCRIPTION
Companion piece to #873. This should make vanilla levels nicer for people who don't want to use the vanilla camera in them for some reason.

Tested a fast64 export and it cleared the camera triggers just fine.