### PR TITLE
Tie Bowser key celebration to key model rather than course ID

### DIFF
--- a/src/game/ingame_menu.c
+++ b/src/game/ingame_menu.c
@@ -2055,7 +2055,25 @@ void render_course_complete_lvl_info_and_hud_str(void) {
     void **actNameTbl    = segmented_to_virtual(languageTable[gInGameLanguage][2]);
     void **courseNameTbl = segmented_to_virtual(languageTable[gInGameLanguage][1]);
 
-    if (gLastCompletedCourseNum <= COURSE_STAGES_MAX) { // Main courses
+    if (gStarModelLastCollected == MODEL_BOWSER_KEY) { // Bowser courses
+        name = segmented_to_virtual(courseNameTbl[COURSE_NUM_TO_INDEX(gLastCompletedCourseNum)]);
+
+        // Print course name and clear text
+        gSPDisplayList(gDisplayListHead++, dl_ia_text_begin);
+
+        gDPSetEnvColor(gDisplayListHead++, 0, 0, 0, gDialogTextAlpha);
+        print_generic_string(TXT_NAME_X1, 130, name);
+        print_generic_string(TXT_CLEAR_X1, 130, textClear);
+        gDPSetEnvColor(gDisplayListHead++, 255, 255, 255, gDialogTextAlpha);
+        print_generic_string(TXT_NAME_X2, 132, name);
+        print_generic_string(TXT_CLEAR_X2, 132, textClear);
+        gSPDisplayList(gDisplayListHead++, dl_ia_text_end);
+
+        print_hud_course_complete_string(HUD_PRINT_CONGRATULATIONS);
+        print_hud_course_complete_coins(118, 111);
+        play_star_fanfare_and_flash_hud(HUD_FLASH_KEYS, 0);
+        return;
+    } else if (gLastCompletedCourseNum <= COURSE_STAGES_MAX) { // Main courses
         print_hud_course_complete_coins(118, 103);
         play_star_fanfare_and_flash_hud(HUD_FLASH_STARS, (1 << (gLastCompletedStarNum - 1)));
 
@@ -2079,24 +2097,6 @@ void render_course_complete_lvl_info_and_hud_str(void) {
         print_generic_string(CRS_NUM_X3, 167, strCourseNum);
 
         gSPDisplayList(gDisplayListHead++, dl_ia_text_end);
-    } else if (gLastCompletedCourseNum == COURSE_BITDW || gLastCompletedCourseNum == COURSE_BITFS) { // Bowser courses
-        name = segmented_to_virtual(courseNameTbl[COURSE_NUM_TO_INDEX(gLastCompletedCourseNum)]);
-
-        // Print course name and clear text
-        gSPDisplayList(gDisplayListHead++, dl_ia_text_begin);
-
-        gDPSetEnvColor(gDisplayListHead++, 0, 0, 0, gDialogTextAlpha);
-        print_generic_string(TXT_NAME_X1, 130, name);
-        print_generic_string(TXT_CLEAR_X1, 130, textClear);
-        gDPSetEnvColor(gDisplayListHead++, 255, 255, 255, gDialogTextAlpha);
-        print_generic_string(TXT_NAME_X2, 132, name);
-        print_generic_string(TXT_CLEAR_X2, 132, textClear);
-        gSPDisplayList(gDisplayListHead++, dl_ia_text_end);
-
-        print_hud_course_complete_string(HUD_PRINT_CONGRATULATIONS);
-        print_hud_course_complete_coins(118, 111);
-        play_star_fanfare_and_flash_hud(HUD_FLASH_KEYS, 0);
-        return;
     } else { // Castle secret stars
         name = segmented_to_virtual(actNameTbl[COURSE_STAGES_MAX * 6]);
 

--- a/src/game/mario_actions_cutscene.c
+++ b/src/game/mario_actions_cutscene.c
@@ -1122,8 +1122,7 @@ s32 act_exit_land_save_dialog(struct MarioState *m) {
             set_mario_animation(m, m->actionArg == 0 ? MARIO_ANIM_GENERAL_LAND
                                                      : MARIO_ANIM_LAND_FROM_SINGLE_JUMP);
             if (is_anim_past_end(m)) {
-                if (gLastCompletedCourseNum != COURSE_BITDW
-                    && gLastCompletedCourseNum != COURSE_BITFS) {
+                if (gStarModelLastCollected != MODEL_BOWSER_KEY) {
                     enable_time_stop();
                 }
 
@@ -1134,8 +1133,7 @@ s32 act_exit_land_save_dialog(struct MarioState *m) {
                 if (!(m->flags & MARIO_CAP_ON_HEAD)) {
                     m->actionState = ACT_STATE_EXIT_LAND_SAVE_DIALOG_NO_CAP; // star exit without cap
                 }
-                if (gLastCompletedCourseNum == COURSE_BITDW
-                 || gLastCompletedCourseNum == COURSE_BITFS) {
+                if (gStarModelLastCollected == MODEL_BOWSER_KEY) {
                     m->actionState = ACT_STATE_EXIT_LAND_SAVE_DIALOG_KEY; // key exit
                 }
             }


### PR DESCRIPTION
This should allow people to put course-exiting ordinary stars into Bowser courses without playing a key animation. Similarly, this will allow Bowser fights to exist in ordinary levels without playing the standard star animation on level exit. Save flags for keys still need to be handled manually in these cases though.

Addresses #686.