### PR TITLE
Replace render_multi_image() with draw_sprite()

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ Thanks to Frame#5375 and AloXado320 for also helping with silhouette stuff
 - This repo supports a much better implementation of reverb over vanilla's fake echo reverb. Great for caves or eerie levels, as well as just a better audio experience in general. See `audio/synthesis.c` for more details and configuration info. (By ArcticJaguar725) *
 - Fazana's "puppyprint" text engine. *
   - Use `print_small_text` to print normal text. The two last params are aligment and how many characters to print (-1 means PRINT_ALL).
-  - Use `render_multi_image` to draw large texture rectangles consisting of multiple images on the screen.
   - More info in `puppyprint.c`
 - Wiseguy's Farcall TLB mapping allows to store executable code inside uncompressed segments, that can be loaded and ran as needed, instead of it having to be loaded at all times. See `farcall.h` in the include folder for instructions and details.
 - Red Coin Stars now support up to 99 red coins! In addition, multi-area red coin missions can now be created by setting the 2nd behavior paramater of the red coin star to the number of reds required for the star to spawn.

--- a/src/game/hud.c
+++ b/src/game/hud.c
@@ -81,6 +81,24 @@ void print_fps(s32 x, s32 y) {
  * Most of the primitive display list commands will still need to be set manually outside of this function
  * (e.g. combiner, envcolor, texture filter, etc.)
  * 
+ * Note that 1-cycle must be used with this function, as it will not render correctly with copy mode.
+ * 
+ * Display List Example Setup:
+ *   gDPPipeSync        (gDisplayListHead++);
+ *   gDPSetTexturePersp (gDisplayListHead++, G_TP_NONE);
+ *   gDPSetCombineMode  (gDisplayListHead++, G_CC_FADEA, G_CC_FADEA);
+ *   gDPSetTextureFilter(gDisplayListHead++, G_TF_POINT);
+ *   gDPSetCycleType    (gDisplayListHead++, G_CYC_1CYCLE);
+ *   gDPSetRenderMode   (gDisplayListHead++, G_RM_XLU_SURF, G_RM_XLU_SURF2);
+ *   gDPSetEnvColor     (gDisplayListHead++, 255, 255, 255, alpha);
+ *
+ *   draw_sprite(&gDisplayListHead, ...);
+ *
+ *   gDPPipeSync        (gDisplayListHead++);
+ *   gDPSetTexturePersp (gDisplayListHead++, G_TP_PERSP);
+ *   gDPSetCombineMode  (gDisplayListHead++, G_CC_SHADE, G_CC_SHADE);
+ *   gDPSetTextureFilter(gDisplayListHead++, G_TF_BILERP);
+ * 
  * Helper function initially provided by devwizard (this has since been modified).
  * 
  * @param dl The address of the display list head to use. Most commonly, this will be "&gDisplayListHead".

--- a/src/game/hud.c
+++ b/src/game/hud.c
@@ -74,7 +74,156 @@ void print_fps(s32 x, s32 y) {
 #endif
 }
 
-// ------------ END OF FPS COUNER -----------------
+/**
+ * @brief Print a large texture to the screen.
+ * 
+ * This function can render an image of any size to the screen, supporting scale adjustments if desirable.
+ * Most of the primitive display list commands will still need to be set manually outside of this function
+ * (e.g. combiner, envcolor, texture filter, etc.)
+ * 
+ * Helper function initially provided by devwizard (this has since been modified).
+ * 
+ * @param dl The address of the display list head to use. Most commonly, this will be "&gDisplayListHead".
+ * @param texture The address of the texture to be rendered to the screen.
+ * @param dlImgFormat The display list image format to be used for the texture.
+ *   This function does not currently support CI textures.
+ *   Example: "G_IM_FMT_RGBA"
+ * @param dlImgSize The bit depth to be used for the texture.
+ *   Example: "G_IM_SIZ_32b" for RGBA32 textures
+ * @param bilerp Boolean for whether bilinear filtering should be used instead of point filtering.
+ *   The actual texture filter display list command will need to be applied outside of this function.
+ * @param textureWidth The pixel width of the source texture file.
+ * @param textureHeight The pixel height of the source texture file.
+ * @param x The x position from the left side of the screen to the left side of the texture.
+ * @param y The y position from the top of the screen to the top of the texture.
+ * @param displayWidth How wide the image should render, in pixels. This should match textureWidth if no change.
+ * @param displayHeight How tall the image should render, in pixels. This should match textureHeight if no change.
+ */
+void draw_sprite(Gfx **dl, const void *texture, s32 dlImgFormat, s32 dlImgSize, s32 bilerp,
+        u32 textureWidth, u32 textureHeight, f32 x, f32 y, f32 displayWidth, f32 displayHeight) {
+    Gfx *dlHead = *dl;
+    s32 sizeLoad = dlImgSize;
+    s32 sizeLine = dlImgSize;
+    s32 shift = 0;
+
+    if (displayWidth <= 0.0f || displayHeight <= 0.0f) {
+        // Cannot display negative width/height
+        return;
+    }
+
+    u32 shiftedDisplayWidth = (u32) roundf(displayWidth * 4.0f);
+    u32 shiftedDisplayHeight = (u32) roundf(displayHeight * 4.0f);
+    s32 shiftedX = roundf(x * 4.0f);
+    s32 shiftedY = roundf(y * 4.0f);
+
+    if (shiftedDisplayWidth == 0 || shiftedDisplayHeight == 0 || textureWidth == 0 || textureHeight == 0) {
+        // Div by 0
+        return;
+    }
+
+    u32 cw = 16 * (0x2448 >> (4 * dlImgSize) & 0xF);
+    u32 ch = 16 * (0x2244 >> (4 * dlImgSize) & 0xF);
+    u32 dsdx = ((0x400 * 4 * textureWidth ) + (shiftedDisplayWidth  / 2)) / shiftedDisplayWidth;
+    u32 dtdy = ((0x400 * 4 * textureHeight) + (shiftedDisplayHeight / 2)) / shiftedDisplayHeight;
+
+    if (dlImgSize == G_IM_SIZ_4b) {
+        sizeLoad = G_IM_SIZ_8b;
+        shift = 1;
+    }
+    if (dlImgSize == G_IM_SIZ_32b) {
+        sizeLine = G_IM_SIZ_16b;
+    }
+    if (bilerp) {
+        cw -= 2 << shift;
+        ch -= 2 << shift;
+    }
+
+    gDPSetTextureImage(dlHead++, dlImgFormat, sizeLoad, textureWidth >> shift, texture);
+
+    for (u32 ty = 0; ty < textureHeight; ty += ch) {
+        u32 ult = ty;
+        u32 lrt = ty + ch;
+        if (lrt > textureHeight) {
+            lrt = textureHeight;
+        }
+
+        s32 yl = shiftedY + ult * shiftedDisplayHeight / textureHeight;
+        s32 yh = shiftedY + lrt * shiftedDisplayHeight / textureHeight;
+        if (yh < 0 || yl > 4096) {
+            continue;
+        }
+
+        s32 t = ult << 5;
+        if (yl < 0) {
+            t -= (yl * dtdy) >> 7;
+            yl = 0;
+        }
+
+        if (bilerp) {
+            if (ult > 0) {
+                ult -= (1 << shift);
+            }
+            if (lrt < textureHeight) {
+                lrt += (1 << shift);
+            }
+            t -= 16;
+        }
+
+        for (u32 tx = 0; tx < textureWidth; tx += cw) {
+            u32 uls = tx;
+            u32 lrs = tx + cw;
+            if (lrs > textureWidth) {
+                lrs = textureWidth;
+            }
+
+            s32 xl = shiftedX + uls * shiftedDisplayWidth / textureWidth;
+            s32 xh = shiftedX + lrs * shiftedDisplayWidth / textureWidth;
+            if (xh < 0 || xl > 4096) {
+                continue;
+            }
+
+            s32 s = uls << 5;
+            if (xl < 0) {
+                s -= (xl * dsdx) >> 7;
+                xl = 0;
+            }
+
+            if (bilerp) {
+                if (uls > 0) {
+                    uls -= (1 << shift);
+                }
+                if (lrs < textureWidth) {
+                    lrs += (1 << shift);
+                }
+                s -= 16;
+            }
+
+            u32 line = (((lrs - uls) << sizeLine) + 14) >> 4;
+
+            gDPPipeSync(dlHead++);
+            gDPSetTile(dlHead++, dlImgFormat, sizeLoad, line, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+            gDPLoadSync(dlHead++);
+            gDPLoadTile(
+                dlHead++, 0,
+                (uls    ) << G_TEXTURE_IMAGE_FRAC >> shift,
+                (ult    ) << G_TEXTURE_IMAGE_FRAC,
+                (lrs - 1) << G_TEXTURE_IMAGE_FRAC >> shift,
+                (lrt - 1) << G_TEXTURE_IMAGE_FRAC);
+            gDPSetTile(
+                dlHead++, dlImgFormat, dlImgSize, line, 0, 0, 0,
+                G_TX_CLAMP, 0, 0, G_TX_CLAMP, 0, 0);
+            gDPSetTileSize(
+                dlHead++, 0,
+                (uls    ) << G_TEXTURE_IMAGE_FRAC,
+                (ult    ) << G_TEXTURE_IMAGE_FRAC,
+                (lrs - 1) << G_TEXTURE_IMAGE_FRAC,
+                (lrt - 1) << G_TEXTURE_IMAGE_FRAC);
+            gSPTextureRectangle(dlHead++, xl, yl, xh, yh, 0, s, t, dsdx, dtdy);
+        }
+    }
+
+    *dl = dlHead;
+}
 
 struct PowerMeterHUD {
     s8 animation;

--- a/src/game/hud.h
+++ b/src/game/hud.h
@@ -42,6 +42,8 @@ enum CameraHUDLUT {
     GLYPH_CAM_ARROW_DOWN
 };
 
+void draw_sprite(Gfx **dl, const void *texture, s32 dlImgFormat, s32 dlImgSize, s32 bilerp,
+        u32 textureWidth, u32 textureHeight, f32 x, f32 y, f32 displayWidth, f32 displayHeight);
 void set_hud_camera_status(s16 status);
 void render_hud(void);
 

--- a/src/game/puppyprint.h
+++ b/src/game/puppyprint.h
@@ -141,7 +141,6 @@ extern s32 print_set_envcolour(u8 r, u8 g, u8 b, u8 a);
 extern void prepare_blank_box(void);
 extern void finish_blank_box(void);
 extern void print_small_text(s32 x, s32 y, const char *str, s32 align, s32 amount, u8 font);
-extern void render_multi_image(Texture *image, s32 x, s32 y, s32 width, s32 height, s32 scaleX, s32 scaleY, s32 mode);
 extern s32  get_text_height(const char *str);
 extern s32  get_text_width(const char *str, s32 font);
 extern void prepare_blank_box(void);


### PR DESCRIPTION
This function is more stable and can handle more use cases than `render_multi_image()` could. It can handle fractional scaling and also doesn't suffer from the seams that ParaLLEl displays when upscaling texrects.

It does have some minor drawbacks though, mainly that it doesn't handle the complete displaylist for the user (mainly to allow customization of primitives outside of the function). It also isn't currently as optimized as `render_multi_image()` was for combiner and render modes (also copy mode does not render correctly).

Neither function supports rendering of CI textures still.