### PR TITLE
Fixed incorrect RDP sync in act select menu

### DIFF
--- a/levels/menu/leveldata.c
+++ b/levels/menu/leveldata.c
@@ -1788,9 +1788,9 @@ const Gfx dl_menu_rgba16_wood_course_end[] = {
     gsDPSetTileSize(0, 0, 0, (64 - 1) << G_TEXTURE_IMAGE_FRAC, (32 - 1) << G_TEXTURE_IMAGE_FRAC),
     gsSPVertex(vertex_menu_course_lower, 4, 0),
     gsSP2Triangles( 0,  1,  2, 0x0,  0,  2,  3, 0x0),
-    gsDPSetRenderMode(G_RM_AA_ZB_OPA_SURF, G_RM_AA_ZB_OPA_SURF2),
     gsSPTexture(0x0001, 0x0001, 0, G_TX_RENDERTILE, G_OFF),
     gsDPPipeSync(),
+    gsDPSetRenderMode(G_RM_AA_ZB_OPA_SURF, G_RM_AA_ZB_OPA_SURF2),
     gsDPSetCombineMode(G_CC_SHADE, G_CC_SHADE),
     gsSPEndDisplayList(),
 };


### PR DESCRIPTION
DPRenderMode is not allowed to be changed before DPPipeSync is done. This causes crashes on act select with F3DEX3 during tri draw before.