### PR TITLE
Bugfix: Floating platform in JRB rises instead of sinks when Mario stands on its edge

### DIFF
--- a/src/game/behaviors/floating_platform.inc.c
+++ b/src/game/behaviors/floating_platform.inc.c
@@ -20,7 +20,7 @@ void floating_platform_act_move_to_home(void) {
         f32 dz = gMarioObject->header.gfx.pos[2] - o->oPosZ;
         f32 cy = coss(-o->oMoveAngleYaw);
         f32 sy = sins(-o->oMoveAngleYaw);
-        o->oFaceAnglePitch = ((dz * cy) + (dx * sy)) * 2;
+        o->oFaceAnglePitch = ((dz * cy) - (dx * sy)) * 2;
         o->oFaceAngleRoll = -((dx * cy) + (dz * sy)) * 2;
         o->oVelY -= 1.0f;
         if (o->oVelY < 0.0f) {
@@ -56,7 +56,6 @@ void floating_platform_act_move_to_home(void) {
 void bhv_floating_platform_loop(void) {
     o->oHomeY = floating_platform_find_home_y();
 
-    // o->oAction = o->oFloatingPlatformIsOnFloor;
     if (o->oFloatingPlatformIsOnFloor) {
         o->oPosY = o->oHomeY;
     } else {


### PR DESCRIPTION
This was introduced back in 2021 by some very absolutely quite small changes :)