### PR TITLE
Fix build errors and warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,7 +322,7 @@ ifeq ($(filter clean distclean print-%,$(MAKECMDGOALS)),)
 
   # Make tools if out of date
   $(info Building tools...)
-  DUMMY != $(MAKE) -s -C $(TOOLS_DIR) >&2 || echo FAIL
+  DUMMY != "$(MAKE)" -s -C $(TOOLS_DIR) >&2 || echo FAIL
     ifeq ($(DUMMY),FAIL)
       $(error Failed to build tools)
     endif
@@ -584,12 +584,12 @@ clean:
 	$(RM) -r $(BUILD_DIR_BASE)
 
 rebuildtools:
-	$(MAKE) -C tools distclean
-	$(MAKE) -C tools
+	"$(MAKE)" -C tools distclean
+	"$(MAKE)" -C tools
 
 distclean: clean
 	$(PYTHON) extract_assets.py --clean
-	$(MAKE) -C $(TOOLS_DIR) clean
+	"$(MAKE)" -C $(TOOLS_DIR) clean
 
 test: $(ROM)
 	$(EMULATOR) $(EMU_FLAGS) $<

--- a/extract_assets.py
+++ b/extract_assets.py
@@ -65,13 +65,17 @@ def remove_file(fname):
 def clean_assets(local_asset_file):
     assets = set(read_asset_map().keys())
     assets.update(read_local_asset_list(local_asset_file))
-    for fname in list(assets) + [".assets-local.txt"]:
+    for fname in list(assets):
         if fname.startswith("@"):
             continue
         try:
             remove_file(fname)
         except FileNotFoundError:
             pass
+
+    if local_asset_file is not None:
+        local_asset_file.close()
+        remove_file(".assets-local.txt")
 
 def usage():
     all_langs = ["jp", "us", "eu", "sh"]

--- a/tools/FlipsSrc/Flips.cpp
+++ b/tools/FlipsSrc/Flips.cpp
@@ -12,7 +12,7 @@
 //get rid of dependencies on libstdc++, they waste 200KB on this platform
 void* operator new(size_t n) { return malloc(n); } // forget allocation failures, let them segfault.
 void operator delete(void * p) { free(p); }
-void operator delete(void * p, size_t n) { free(p); }
+void operator delete(void * p, unused size_t n) { free(p); }
 extern "C" void __cxa_pure_virtual() { abort(); }
 
 #if __GNUC__ && (__cpp_rtti || __cpp_exceptions)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -10,9 +10,7 @@ LDFLAGS      := -lm
 ALL_PROGRAMS := armips filesizer lz4tpack deflatepack rncpack n64graphics n64graphics_ci mio0 slienc n64cksum textconv aifc_decode aiff_extract_codebook vadpcm_enc tabledesign extract_data_for_mio skyconv
 LIBAUDIOFILE := audiofile/libaudiofile.a
 
-OS := $(shell uname)
-
-ifneq ($(OS), Darwin)
+ifneq ($(shell uname), Darwin)
   ALL_PROGRAMS += flips
 endif
 
@@ -61,7 +59,7 @@ textconv_SOURCES := textconv.c utf8.c hashtable.c
 
 aifc_decode_SOURCES := aifc_decode.c
 
-aiff_extract_codebook: $(LIBAUDIOFILE)
+aiff_extract_codebook$(EXT): $(LIBAUDIOFILE)
 aiff_extract_codebook_SOURCES := aiff_extract_codebook.c sdk-tools/tabledesign/codebook.c sdk-tools/tabledesign/estimate.c sdk-tools/tabledesign/print.c sdk-tools/tabledesign/tabledesign.c
 aiff_extract_codebook_CFLAGS  := -DEXTRACT_CODEBOOK -Iaudiofile -Wno-uninitialized
 aiff_extract_codebook_LDFLAGS := -Laudiofile -laudiofile -lstdc++
@@ -109,7 +107,7 @@ all: all-except-recomp
 clean:
 	$(RM) $(ALL_PROGRAMS)
 	$(RM) UNFLoader*
-	$(MAKE) -C audiofile clean
+	"$(MAKE)" -C audiofile clean
 
 distclean: clean
 
@@ -121,6 +119,6 @@ endef
 $(foreach p,$(BUILD_PROGRAMS),$(eval $(call COMPILE,$(p))))
 
 $(LIBAUDIOFILE):
-	@$(MAKE) -C audiofile
+	@"$(MAKE)" -C audiofile
 
 .PHONY: all all-except-recomp clean distclean default


### PR DESCRIPTION
Builds without errors or warnings for me using Fedora 43 and Windows 11 with MinGW. 

Fixes:
* Close .assets-local.txt before attempting to remove it in extract_assets.py
* Quote uses of $(MAKE), since leaving it bare can break if the path to the executable has spaces
* Suppress warning for unused parameter in Flips.cpp
* Don't override OS environment variable, since it broke MinGW builds
* Specify extension for aiff_extract_codebook target, fixes dependency order issue for MinGW