### PR TITLE
Fix Goddard not building with MinGW

### DIFF
--- a/sm64.ld
+++ b/sm64.ld
@@ -90,6 +90,8 @@ OUTPUT_ARCH (mips)
    _##name##_mio0SegmentRomStart = _##name##_yay0SegmentRomStart; \
    _##name##_mio0SegmentRomEnd = _##name##_yay0SegmentRomEnd;
 
+#define LIBGODDARD_A BUILD_DIR[/\\]libgoddard.a
+
 SECTIONS
 {
    __romPos = 0;
@@ -360,30 +362,30 @@ SECTIONS
       KEEP(BUILD_DIR/src/menu*.o(.data*));
       KEEP(BUILD_DIR/src/menu*.o(.rodata*));
 #ifdef KEEP_MARIO_HEAD
-      KEEP(BUILD_DIR/libgoddard.a:*.o(.text*));
-      KEEP(BUILD_DIR/libgoddard.a:gd_main.o(.data*));
-      KEEP(BUILD_DIR/libgoddard.a:draw_objects.o(.data*));
-      KEEP(BUILD_DIR/libgoddard.a:objects.o(.data*));
-      KEEP(BUILD_DIR/libgoddard.a:particles.o(.data*));
-      KEEP(BUILD_DIR/libgoddard.a:dynlist_proc.o(.data*));
-      KEEP(BUILD_DIR/libgoddard.a:debug_utils.o(.data*));
-      KEEP(BUILD_DIR/libgoddard.a:joints.o(.data*));
-      KEEP(BUILD_DIR/libgoddard.a:shape_helper.o(.data*));
-      KEEP(BUILD_DIR/libgoddard.a:renderer.o(.data*));
-      KEEP(BUILD_DIR/libgoddard.a:gd_main.o(.rodata*));
-      KEEP(BUILD_DIR/libgoddard.a:gd_memory.o(.rodata*));
-      KEEP(BUILD_DIR/libgoddard.a:draw_objects.o(.rodata*));
-      KEEP(BUILD_DIR/libgoddard.a:objects.o(.rodata*));
-      KEEP(BUILD_DIR/libgoddard.a:skin_movement.o(.rodata*));
-      KEEP(BUILD_DIR/libgoddard.a:particles.o(.rodata*));
-      KEEP(BUILD_DIR/libgoddard.a:dynlist_proc.o(.rodata*));
-      KEEP(BUILD_DIR/libgoddard.a:old_menu.o(.rodata*));
-      KEEP(BUILD_DIR/libgoddard.a:debug_utils.o(.rodata*));
-      KEEP(BUILD_DIR/libgoddard.a:joints.o(.rodata*));
-      KEEP(BUILD_DIR/libgoddard.a:skin.o(.rodata*));
-      KEEP(BUILD_DIR/libgoddard.a:gd_math.o(.rodata*));
-      KEEP(BUILD_DIR/libgoddard.a:shape_helper.o(.rodata*));
-      KEEP(BUILD_DIR/libgoddard.a:renderer.o(.rodata*));
+      KEEP(LIBGODDARD_A:*.o(.text*));
+      KEEP(LIBGODDARD_A:gd_main.o(.data*));
+      KEEP(LIBGODDARD_A:draw_objects.o(.data*));
+      KEEP(LIBGODDARD_A:objects.o(.data*));
+      KEEP(LIBGODDARD_A:particles.o(.data*));
+      KEEP(LIBGODDARD_A:dynlist_proc.o(.data*));
+      KEEP(LIBGODDARD_A:debug_utils.o(.data*));
+      KEEP(LIBGODDARD_A:joints.o(.data*));
+      KEEP(LIBGODDARD_A:shape_helper.o(.data*));
+      KEEP(LIBGODDARD_A:renderer.o(.data*));
+      KEEP(LIBGODDARD_A:gd_main.o(.rodata*));
+      KEEP(LIBGODDARD_A:gd_memory.o(.rodata*));
+      KEEP(LIBGODDARD_A:draw_objects.o(.rodata*));
+      KEEP(LIBGODDARD_A:objects.o(.rodata*));
+      KEEP(LIBGODDARD_A:skin_movement.o(.rodata*));
+      KEEP(LIBGODDARD_A:particles.o(.rodata*));
+      KEEP(LIBGODDARD_A:dynlist_proc.o(.rodata*));
+      KEEP(LIBGODDARD_A:old_menu.o(.rodata*));
+      KEEP(LIBGODDARD_A:debug_utils.o(.rodata*));
+      KEEP(LIBGODDARD_A:joints.o(.rodata*));
+      KEEP(LIBGODDARD_A:skin.o(.rodata*));
+      KEEP(LIBGODDARD_A:gd_math.o(.rodata*));
+      KEEP(LIBGODDARD_A:shape_helper.o(.rodata*));
+      KEEP(LIBGODDARD_A:renderer.o(.rodata*));
 #endif
       . = ALIGN(16);
    }
@@ -392,7 +394,7 @@ SECTIONS
    {
       KEEP(BUILD_DIR/src/menu*.o(.bss*));
 #ifdef KEEP_MARIO_HEAD
-      KEEP(BUILD_DIR/libgoddard.a:*.o(.bss*));
+      KEEP(LIBGODDARD_A:*.o(.bss*));
 #endif
       . = ALIGN(16);
    }
@@ -431,23 +433,23 @@ SECTIONS
 #ifdef KEEP_MARIO_HEAD
    BEGIN_SEG(gd_dynlists, 0x04000000)
    {
-      BUILD_DIR/libgoddard.a:dynlist_test_cube.o(.data*);
-      BUILD_DIR/libgoddard.a:dynlist_unused.o(.data*);
-      BUILD_DIR/libgoddard.a:dynlist_mario_face.o(.data*);
-      BUILD_DIR/libgoddard.a:dynlists_mario_eyes.o(.data*);
-      BUILD_DIR/libgoddard.a:dynlists_mario_eyebrows_mustache.o(.data*);
-      BUILD_DIR/libgoddard.a:dynlist_mario_master.o(.data*);
-      BUILD_DIR/libgoddard.a:anim_mario_mustache_right.o(.data*);
-      BUILD_DIR/libgoddard.a:anim_mario_mustache_left.o(.data*);
-      BUILD_DIR/libgoddard.a:anim_mario_lips_1.o(.data*);
-      BUILD_DIR/libgoddard.a:anim_mario_lips_2.o(.data*);
-      BUILD_DIR/libgoddard.a:anim_mario_eyebrows_1.o(.data*);
-      BUILD_DIR/libgoddard.a:anim_group_1.o(.data*);
-      BUILD_DIR/libgoddard.a:anim_group_2.o(.data*);
-      BUILD_DIR/libgoddard.a:dynlist_test_cube.o(.rodata*);
-      BUILD_DIR/libgoddard.a:dynlist_unused.o(.rodata*);
-      BUILD_DIR/libgoddard.a:*.o(.data*);
-      BUILD_DIR/libgoddard.a:*.o(.rodata*);
+      LIBGODDARD_A:dynlist_test_cube.o(.data*);
+      LIBGODDARD_A:dynlist_unused.o(.data*);
+      LIBGODDARD_A:dynlist_mario_face.o(.data*);
+      LIBGODDARD_A:dynlists_mario_eyes.o(.data*);
+      LIBGODDARD_A:dynlists_mario_eyebrows_mustache.o(.data*);
+      LIBGODDARD_A:dynlist_mario_master.o(.data*);
+      LIBGODDARD_A:anim_mario_mustache_right.o(.data*);
+      LIBGODDARD_A:anim_mario_mustache_left.o(.data*);
+      LIBGODDARD_A:anim_mario_lips_1.o(.data*);
+      LIBGODDARD_A:anim_mario_lips_2.o(.data*);
+      LIBGODDARD_A:anim_mario_eyebrows_1.o(.data*);
+      LIBGODDARD_A:anim_group_1.o(.data*);
+      LIBGODDARD_A:anim_group_2.o(.data*);
+      LIBGODDARD_A:dynlist_test_cube.o(.rodata*);
+      LIBGODDARD_A:dynlist_unused.o(.rodata*);
+      LIBGODDARD_A:*.o(.data*);
+      LIBGODDARD_A:*.o(.rodata*);
    }
    END_SEG(gd_dynlists)
 #endif


### PR DESCRIPTION
Resolves #932, checked working on Windows 11 (MinGW) and Fedora 43.