### PR TITLE
Fix gMarioState->lastSafePos not updating in some cases

### DIFF
--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -362,6 +362,11 @@ void init_mario_after_warp(void) {
         gPlayerSpawnInfos[0].startAngle[0] = 0;
         gPlayerSpawnInfos[0].startAngle[1] = object->oMoveAngleYaw;
         gPlayerSpawnInfos[0].startAngle[2] = 0;
+        
+        struct Surface *floor;
+        gMarioState->lastSafePos[0] = object->oPosX;
+        gMarioState->lastSafePos[1] = find_floor(object->oPosX, object->oPosY, object->oPosZ, &floor);
+        gMarioState->lastSafePos[2] = object->oPosZ;
 
         if (marioSpawnType == MARIO_SPAWN_DOOR_WARP) {
             init_door_warp(&gPlayerSpawnInfos[0], sWarpDest.arg);

--- a/src/game/mario.c
+++ b/src/game/mario.c
@@ -1754,6 +1754,12 @@ s32 execute_mario_action(UNUSED struct Object *obj) {
             return ACTIVE_PARTICLE_NONE;
         }
 
+        // H64 TODO: Add config opt & check if floor is slippery
+        u32 actGroup = gMarioState->action & ACT_GROUP_MASK;
+        if ((actGroup == ACT_GROUP_STATIONARY || actGroup == ACT_GROUP_MOVING) && !SURFACE_IS_UNSAFE(gMarioState->floor->type)) {
+            vec3f_copy(gMarioState->lastSafePos, gMarioState->pos);
+        }
+
         // The function can loop through many action shifts in one frame,
         // which can lead to unexpected sub-frame behavior. Could potentially hang
         // if a loop of actions were found, but there has not been a situation found.

--- a/src/game/mario.c
+++ b/src/game/mario.c
@@ -1799,7 +1799,10 @@ s32 execute_mario_action(UNUSED struct Object *obj) {
 
         // H64 TODO: Add config opt & check if floor is slippery
         u32 actGroup = gMarioState->action & ACT_GROUP_MASK;
-        if ((actGroup == ACT_GROUP_STATIONARY || actGroup == ACT_GROUP_MOVING) && gMarioState->floor != NULL && !SURFACE_IS_UNSAFE(gMarioState->floor->type)) {
+        if ((actGroup == ACT_GROUP_STATIONARY || actGroup == ACT_GROUP_MOVING) && 
+            gMarioState->floor != NULL && 
+            !SURFACE_IS_UNSAFE(gMarioState->floor->type) &&
+            !mario_floor_is_slippery(gMarioState)) {
             vec3f_copy(gMarioState->lastSafePos, gMarioState->pos);
         }
 

--- a/src/game/mario.c
+++ b/src/game/mario.c
@@ -1754,12 +1754,6 @@ s32 execute_mario_action(UNUSED struct Object *obj) {
             return ACTIVE_PARTICLE_NONE;
         }
 
-        // H64 TODO: Add config opt & check if floor is slippery
-        u32 actGroup = gMarioState->action & ACT_GROUP_MASK;
-        if ((actGroup == ACT_GROUP_STATIONARY || actGroup == ACT_GROUP_MOVING) && !SURFACE_IS_UNSAFE(gMarioState->floor->type)) {
-            vec3f_copy(gMarioState->lastSafePos, gMarioState->pos);
-        }
-
         // The function can loop through many action shifts in one frame,
         // which can lead to unexpected sub-frame behavior. Could potentially hang
         // if a loop of actions were found, but there has not been a situation found.
@@ -1802,6 +1796,12 @@ s32 execute_mario_action(UNUSED struct Object *obj) {
 #if ENABLE_RUMBLE
         queue_rumble_particles(gMarioState);
 #endif
+
+        // H64 TODO: Add config opt & check if floor is slippery
+        u32 actGroup = gMarioState->action & ACT_GROUP_MASK;
+        if ((actGroup == ACT_GROUP_STATIONARY || actGroup == ACT_GROUP_MOVING) && gMarioState->floor != NULL && !SURFACE_IS_UNSAFE(gMarioState->floor->type)) {
+            vec3f_copy(gMarioState->lastSafePos, gMarioState->pos);
+        }
 
         return gMarioState->particleFlags;
     }

--- a/src/game/mario.c
+++ b/src/game/mario.c
@@ -1797,7 +1797,6 @@ s32 execute_mario_action(UNUSED struct Object *obj) {
         queue_rumble_particles(gMarioState);
 #endif
 
-        // H64 TODO: Add config opt & check if floor is slippery
         u32 actGroup = gMarioState->action & ACT_GROUP_MASK;
         if ((actGroup == ACT_GROUP_STATIONARY || actGroup == ACT_GROUP_MOVING) && 
             gMarioState->floor != NULL && 

--- a/src/game/mario_step.c
+++ b/src/game/mario_step.c
@@ -315,11 +315,6 @@ static s32 perform_ground_quarter_step(struct MarioState *m, Vec3f nextPos) {
 
     vec3f_set(m->pos, nextPos[0], floorHeight, nextPos[2]);
 
-    // H64 TODO: Add config opt & check if floor is slippery
-    if (!SURFACE_IS_UNSAFE(floor->type)) {
-        vec3f_copy(m->lastSafePos, m->pos);
-    }
-
     set_mario_floor(m, floor, floorHeight);
 
     if (m->wall != NULL) {

--- a/src/game/object_list_processor.c
+++ b/src/game/object_list_processor.c
@@ -280,6 +280,12 @@ void bhv_mario_update(void) {
 
         i++;
     }
+
+    // H64 TODO: Add config opt & check if floor is slippery
+    u32 actGroup = gMarioState->action & ACT_GROUP_MASK;
+    if ((actGroup == ACT_GROUP_STATIONARY || actGroup == ACT_GROUP_MOVING) && !SURFACE_IS_UNSAFE(gMarioState->floor->type)) {
+        vec3f_copy(gMarioState->lastSafePos, gMarioState->pos);
+    }
 }
 
 /**

--- a/src/game/object_list_processor.c
+++ b/src/game/object_list_processor.c
@@ -283,7 +283,7 @@ void bhv_mario_update(void) {
 
     // H64 TODO: Add config opt & check if floor is slippery
     u32 actGroup = gMarioState->action & ACT_GROUP_MASK;
-    if ((actGroup == ACT_GROUP_STATIONARY || actGroup == ACT_GROUP_MOVING) && !SURFACE_IS_UNSAFE(gMarioState->floor->type)) {
+    if ((actGroup == ACT_GROUP_STATIONARY || actGroup == ACT_GROUP_MOVING) && gMarioState->floor != NULL && !SURFACE_IS_UNSAFE(gMarioState->floor->type)) {
         vec3f_copy(gMarioState->lastSafePos, gMarioState->pos);
     }
 }

--- a/src/game/object_list_processor.c
+++ b/src/game/object_list_processor.c
@@ -280,12 +280,6 @@ void bhv_mario_update(void) {
 
         i++;
     }
-
-    // H64 TODO: Add config opt & check if floor is slippery
-    u32 actGroup = gMarioState->action & ACT_GROUP_MASK;
-    if ((actGroup == ACT_GROUP_STATIONARY || actGroup == ACT_GROUP_MOVING) && gMarioState->floor != NULL && !SURFACE_IS_UNSAFE(gMarioState->floor->type)) {
-        vec3f_copy(gMarioState->lastSafePos, gMarioState->pos);
-    }
 }
 
 /**


### PR DESCRIPTION
Fixes #931. Also fixes the last safe position not being updated if the player performs a frame perfect jump.

In that issue, Arctic suggested updating the last safe position to the floor position of a destination warp after it is used. I haven't done that here, because the position under the warp might not be safe if Mario is meant to exit it with horizontal velocity.